### PR TITLE
Add filename to NiFTI filepath so saving multilabel NiFTI with --ml works

### DIFF
--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -295,7 +295,7 @@ def nnUNet_predict_image(file_in, file_out, task_id, model="3d_fullres", folds=N
                 file_out.mkdir(exist_ok=True, parents=True)
             if multilabel_image:
                 # nib.save(nib.Nifti1Image(img_data, img_pred.affine, new_header), file_out)  # recreate nifti image to ensure uint8 dtype
-                output_path = str(file_out / f"full_segmentation.nii.gz")
+                output_path = str(file_out / f"segmentation.nii.gz")
                 img_out = nib.Nifti1Image(img_data, img_pred.affine, new_header)
                 save_multilabel_nifti(img_out, output_path, class_map[task_name])
                 if nora_tag != "None":

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -295,8 +295,9 @@ def nnUNet_predict_image(file_in, file_out, task_id, model="3d_fullres", folds=N
                 file_out.mkdir(exist_ok=True, parents=True)
             if multilabel_image:
                 # nib.save(nib.Nifti1Image(img_data, img_pred.affine, new_header), file_out)  # recreate nifti image to ensure uint8 dtype
+                output_path = str(file_out / f"full_segmentation.nii.gz")
                 img_out = nib.Nifti1Image(img_data, img_pred.affine, new_header)
-                save_multilabel_nifti(img_out, file_out, class_map[task_name])
+                save_multilabel_nifti(img_out, output_path, class_map[task_name])
                 if nora_tag != "None":
                     subprocess.call(f"/opt/nora/src/node/nora -p {nora_tag} --add {file_out} --addtag atlas", shell=True)
             else:  # save each class as a separate binary image


### PR DESCRIPTION
The --ml option wasn't working because the path being passed to nib.save() didn't contain a filename. So I added one. 

(The --ml option is supposed to save the entire segmentation to a single .nii.gz)