### PR TITLE
feat: only run relevant models with -rs flag

### DIFF
--- a/bin/TotalSegmentator
+++ b/bin/TotalSegmentator
@@ -57,7 +57,7 @@ def main():
 
     # todo: for 15mm model only run the models which are needed for these rois
     parser.add_argument("-rs", "--roi_subset", type=str, nargs="+",
-                        help="Define a subset of classes to save (space separated list of class names)")
+                        help="Define a subset of classes to save (space separated list of class names). If running 1.5mm model, will only run the appropriate models for these rois.")
 
     parser.add_argument("-s", "--statistics", action="store_true", 
                         help="Calc volume (in mm3) and mean intensity. Results will be in statistics.json",


### PR DESCRIPTION
# Description
Only run the necessary models when a subset of class is defined using the --roi_subset flag.
- Loop through each class part defined in `class_map_5_parts` in the `map_to_binari.py` file
- Check if any organ intersects with the roi subset
- Modify the task ids accordingly