### PR TITLE
FIX: sys.exit return code in nnunet.py

### DIFF
--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -148,8 +148,7 @@ def nnUNet_predict_image(file_in, file_out, task_id, model="3d_fullres", folds=N
     if file_out is not None:
         file_out = Path(file_out)
     if not file_in.exists():
-        print("ERROR: The input file or directory does not exist.")
-        sys.exit()
+        sys.exit("ERROR: The input file or directory does not exist.")
     multimodel = type(task_id) is list
 
     img_type = "nifti" if str(file_in).endswith(".nii") or str(file_in).endswith(".nii.gz") else "dicom"


### PR DESCRIPTION
Default return code is 0, meaning a flawless execution.
By providing a error message directly in sys.exit, message will be printed to stderr and return code will not be 0.
This is useful in pipelines where return codes are used to check for error.