### PR TITLE
Change dtype of ct_img in statistics

### DIFF
--- a/totalsegmentator/statistics.py
+++ b/totalsegmentator/statistics.py
@@ -96,7 +96,7 @@ def get_basic_statistics(seg: np.array, ct_file, file_out: Path, quiet: bool = F
     ct_file: path to a ct_file or a nifti file object
     """
     ct_img = nib.load(ct_file) if type(ct_file) == pathlib.PosixPath else ct_file
-    ct = ct_img.get_fdata()
+    ct = ct_img.get_fdata().astype(np.int16)
     spacing = ct_img.header.get_zooms()
     vox_vol = spacing[0] * spacing[1] * spacing[2]
     stats = {}


### PR DESCRIPTION
When running the tool with all segmentations on an image I encountered statistics runtimes of around 320s, much longer than the prediction + dcm saving time.

Digging into it I noticed that the intensity calculation on https://github.com/wasserth/TotalSegmentator/blob/7825688c39bd03a4b4d50f8a375069c3e202ead8/totalsegmentator/statistics.py#L115 was the biggest slowdown, of around 5s per valid mask.

Notably, the np.average; where the multiplication of both arrays ends up being the most costly operation.

Changing the ct variable to a `np.int16` had no effect on the computed intensity values in the few CTs I tested and yielded a statistics runtime of 39s. Changing it to int8 (or uint8) was evidently faster, but yielded _significant_ impact on intensity values.

I ran this on the Test files provided for the [LCTSC](https://wiki.cancerimagingarchive.net/pages/viewpage.action?pageId=24284539), running the command ` totalsegmentator("/in", "/out", statistics=True, output_type="dicom", fast=False)` for each series. Files are generally of the shape (512, 512, ~130)
