### PR TITLE
Specify updated torch requirement (>=2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ TotalSegmentator works on Ubuntu, Mac, and Windows and on CPU and GPU.
 
 Install dependencies:
 * Python >= 3.9
-* [Pytorch](http://pytorch.org/) >= 1.12.1
+* [Pytorch](http://pytorch.org/) >= 2.0.0
 
 Optionally:
 * if you use the option `--preview` you have to install xvfb (`apt-get install xvfb`)
@@ -151,7 +151,7 @@ if __name__ == "__main__":
     output_img = totalsegmentator(input_img)
     nib.save(output_img, output_path)
 ```
-You can see all available arguments [here](https://github.com/wasserth/TotalSegmentator/blob/master/totalsegmentator/python_api.py). Running from within the main environment should avoid some multiprocessing issues.  
+You can see all available arguments [here](https://github.com/wasserth/TotalSegmentator/blob/master/totalsegmentator/python_api.py). Running from within the main environment should avoid some multiprocessing issues.
 
 The segmentation image contains the names of the classes in the extended header. If you want to load this additional header information you can use the following code:
 ```python

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ import nibabel as nib
 from totalsegmentator.python_api import totalsegmentator
 
 if __name__ == "__main__":
-    # option 1: provide input and output as file pathes
+    # option 1: provide input and output as file paths
     totalsegmentator(input_path, output_path)
 
     # option 2: provide input and output as nifti image objects

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='TotalSegmentator',
         license='Apache 2.0',
         packages=find_packages(),
         install_requires=[
-            'torch>=1.10.2',
+            'torch>=2.0.0',
             'numpy',
             'psutil',
             'SimpleITK',

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -253,8 +253,8 @@ def nnUNetv2_predict(dir_in, dir_out, task_id, model="3d_fullres", folds=None,
     # spacing = input_image.header.get_zooms()
     # # Do i have to transpose spacing? does not matter because anyways isotropic at this point.
     # spacing = (spacing[2], spacing[0], spacing[1])
-    # seg = predictor.predict_single_npy_array(input_data, {"spacing": spacing}, 
-    #                                          prev_stage_predictions, None, 
+    # seg = predictor.predict_single_npy_array(input_data, {"spacing": spacing},
+    #                                          prev_stage_predictions, None,
     #                                          save_probabilities)
     # seg = seg.transpose(1, 2, 0)
     # nib.save(nib.Nifti1Image(seg.astype(np.uint8), input_image.affine), Path(dir_out) / "s01.nii.gz")


### PR DESCRIPTION
As of https://github.com/wasserth/TotalSegmentator/commit/08f6fe36d24b2a804cf713eefcf5c0e1091a59c1, TotalSegmentator actually required torch >1.12 because the dependency nnunetv2 version 2.1 required torch >1.12 https://github.com/MIC-DKFZ/nnUNet/blob/4f03fa27520a974efd676bc4c677f788e4303869/setup.py#L13.

As of https://github.com/wasserth/TotalSegmentator/commit/bf452f50b3ff986a90e4f35dac53045908766f31, TotalSegmentator actually required torch >= 2.0.0 because the dependency nnunetv2 starting with version 2.2 required torch >= 2.0.0 https://github.com/MIC-DKFZ/nnUNet/blob/8f92709af2dd8c4cc02d2ec3d70e861b005059da/pyproject.toml#L33

The torch version requirement in `TotalSegmentator` could be removed if you want `nnunetv2` to drive the version and avoid having to update the documentation in this repo. Of course `TotalSegmentator` could be more strict than its dependencies in which it could maintain its own `torch` version requirement.