### PR TITLE
Fix: use `roi_subset` labels in nifti header if provided

### DIFF
--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -564,7 +564,7 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
         new_header = img_in_orig.header.copy()
         new_header.set_data_dtype(np.uint8)
         img_out = nib.Nifti1Image(img_data, img_pred.affine, new_header)
-        img_out = add_label_map_to_nifti(img_out, class_map[task_name])
+        img_out = add_label_map_to_nifti(img_out, label_map)
 
         if file_out is not None and skip_saving is False:
             if not quiet: print("Saving segmentations...")


### PR DESCRIPTION
Currently, if `roi_subset` is provided during segmentation, the full class map of the task is stored in the nifti header. 

This PR fixes the above issue.
