### PR TITLE
Cuda Device Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The mapping from label ID to class name can be found [here](https://github.com/w
 
 
 ### Advanced settings
-* `--device`: Choose `cpu` or `gpu`
+* `--device`: Choose `cpu` or `gpu` or `desired gpu id (e.g., 1 -> cuda:1)`
 * `--fast`: For faster runtime and less memory requirements use this option. It will run a lower resolution model (3mm instead of 1.5mm).
 * `--roi_subset`: Takes a space-separated list of class names (e.g. `spleen colon brain`) and only predicts those classes. Saves a lot of runtime and memory. Might be less accurate especially for small classes (e.g. prostate).
 * `--preview`: This will generate a 3D rendering of all classes, giving you a quick overview if the segmentation worked and where it failed (see `preview.png` in output directory).
@@ -145,12 +145,15 @@ import nibabel as nib
 from totalsegmentator.python_api import totalsegmentator
 
 if __name__ == "__main__":
+    # specify the device 
+    # 'gpu', 'cpu', 'mps', '1', ...
+    device = '1' ## cuda:1
     # option 1: provide input and output as file paths
-    totalsegmentator(input_path, output_path)
-
+    totalsegmentator(input_path, output_path, device=device)
+    
     # option 2: provide input and output as nifti image objects
     input_img = nib.load(input_path)
-    output_img = totalsegmentator(input_img)
+    output_img = totalsegmentator(input_img, device=device)
     nib.save(output_img, output_path)
 ```
 You can see all available arguments [here](https://github.com/wasserth/TotalSegmentator/blob/master/totalsegmentator/python_api.py). Running from within the main environment should avoid some multiprocessing issues.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The mapping from label ID to class name can be found [here](https://github.com/w
 
 
 ### Advanced settings
-* `--device`: Choose `cpu` or `gpu` or `desired gpu id (e.g., 1 -> cuda:1)`
+* `--device`: Choose `cpu` or `gpu` or `gpu:X (e.g., gpu:1 -> cuda:1)`
 * `--fast`: For faster runtime and less memory requirements use this option. It will run a lower resolution model (3mm instead of 1.5mm).
 * `--roi_subset`: Takes a space-separated list of class names (e.g. `spleen colon brain`) and only predicts those classes. Saves a lot of runtime and memory. Might be less accurate especially for small classes (e.g. prostate).
 * `--preview`: This will generate a 3D rendering of all classes, giving you a quick overview if the segmentation worked and where it failed (see `preview.png` in output directory).
@@ -146,8 +146,8 @@ from totalsegmentator.python_api import totalsegmentator
 
 if __name__ == "__main__":
     # specify the device 
-    # 'gpu', 'cpu', 'mps', '1', ...
-    device = '1' ## cuda:1
+    # 'gpu', 'cpu', 'mps', 'gpu:X'
+    device = 'gpu:1' ## cuda:1
     
     # option 1: provide input and output as file paths
     totalsegmentator(input_path, output_path, device=device)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ if __name__ == "__main__":
     # specify the device 
     # 'gpu', 'cpu', 'mps', '1', ...
     device = '1' ## cuda:1
+    
     # option 1: provide input and output as file paths
     totalsegmentator(input_path, output_path, device=device)
     

--- a/tests/test_device_type.py
+++ b/tests/test_device_type.py
@@ -1,0 +1,20 @@
+from totalsegmentator.bin.TotalSegmentator import validate_device_type
+import unittest
+import argparse
+class TestValidateDeviceType(unittest.TestCase):
+    def test_valid_inputs(self):
+        self.assertEqual(validate_device_type("gpu"), "gpu")
+        self.assertEqual(validate_device_type("cpu"), "cpu")
+        self.assertEqual(validate_device_type("mps"), "mps")
+        self.assertEqual(validate_device_type("gpu:0"), "cuda:0")
+        self.assertEqual(validate_device_type("gpu:1"), "cuda:1")
+
+    def test_invalid_inputs(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            validate_device_type("invalid")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            validate_device_type("gpu:invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_device_selection_api.sh
+++ b/tests/test_python_device_selection_api.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+base_path=$(realpath ../..)
+script_path="$base_path/totalsegmentator/bin/TotalSegmentator.py"
+
+python3 "$script_path" -i "$base_path/tests/reference_files/example_ct_sm.nii.gz" -o "$base_path/tests/unittest_prediction.nii.gz" -bs --ml -d 1
+pytest -v "$base_path/tests/test_end_to_end.py"::test_end_to_end::test_prediction_multilabel

--- a/tests/test_python_device_selection_api.sh
+++ b/tests/test_python_device_selection_api.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-base_path=$(realpath ../..)
-script_path="$base_path/totalsegmentator/bin/TotalSegmentator.py"
-
-python3 "$script_path" -i "$base_path/tests/reference_files/example_ct_sm.nii.gz" -o "$base_path/tests/unittest_prediction.nii.gz" -bs --ml -d 1
-pytest -v "$base_path/tests/test_end_to_end.py"::test_end_to_end::test_prediction_multilabel

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -3,10 +3,11 @@ set -e
 # To run these tests do
 # ./tests/tests.sh
 
-
+# Test device type selection function
+pytest -v tests/test_device_type.py
 
 # Test multilabel prediction
-TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d 1
+TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 
 TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -6,7 +6,10 @@ set -e
 
 
 # Test multilabel prediction
-TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d 0
+TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d 1
+pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
+
+TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 
 # Test organ prediction - roi subset

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -4,8 +4,9 @@ set -e
 # ./tests/tests.sh
 
 
+
 # Test multilabel prediction
-TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu
+TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d 0
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 
 # Test organ prediction - roi subset

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -10,9 +10,6 @@ pytest -v tests/test_device_type.py
 TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 
-TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu
-pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
-
 # Test organ prediction - roi subset
 # 2 cpus:
 #   example_ct_sm.nii.gz: 34s, 3.0GB

--- a/totalsegmentator/bin/TotalSegmentator.py
+++ b/totalsegmentator/bin/TotalSegmentator.py
@@ -103,9 +103,20 @@ def main():
     # "mps" is for apple silicon; the latest pytorch nightly version supports 3D Conv but not ConvTranspose3D which is
     # also needed by nnU-Net. So "mps" not working for now.
     # https://github.com/pytorch/pytorch/issues/77818
-    parser.add_argument("-d", "--device", choices=["gpu", "cpu", "mps"],
-                        help="Device to run on (default: gpu).",
-                        default="gpu")
+
+    def validate_device_type(value):
+        valid_strings = {"gpu", "cpu", "mps"}
+        if value in valid_strings:
+            return value
+        if value.isdigit():
+            return int(value)
+        raise argparse.ArgumentTypeError(f"Invalid device type: '{value}'. Must be 'gpu', 'cpu', 'mps', or or an desired device ID (integer).")
+
+    parser.add_argument("-d",'--device', type=validate_device_type, required=True,
+                        help="Device type: 'GPU', 'CPU', 'MPS', or an desired device ID (integer).")
+    # parser.add_argument("-d", "--device", choices=["gpu", "cpu", "mps"],
+    #                     help="Device to run on (default: gpu).",
+    #                     default="gpu")
 
     parser.add_argument("-q", "--quiet", action="store_true", help="Print no intermediate outputs",
                         default=False)

--- a/totalsegmentator/bin/TotalSegmentator.py
+++ b/totalsegmentator/bin/TotalSegmentator.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import sys
-import os
 import argparse
 from pkg_resources import require
 from pathlib import Path
@@ -119,19 +117,8 @@ def main():
     # "mps" is for apple silicon; the latest pytorch nightly version supports 3D Conv but not ConvTranspose3D which is
     # also needed by nnU-Net. So "mps" not working for now.
     # https://github.com/pytorch/pytorch/issues/77818
-    # def validate_device_type(value):
-    #     valid_strings = {"gpu", "cpu", "mps"}
-    #     if value in valid_strings:
-    #         return value
-    #     if value.isdigit():
-    #         return int(value)
-    #     raise argparse.ArgumentTypeError(f"Invalid device type: '{value}'. Must be 'gpu', 'cpu', 'mps', or or an desired device ID (integer).")
-
     parser.add_argument("-d",'--device', type=validate_device_type, required=True,
                         help="Device type: 'gpu', 'cpu', 'mps', or 'gpu:X' where X is an integer representing the GPU device ID.")
-    # parser.add_argument("-d", "--device", choices=["gpu", "cpu", "mps"],
-    #                     help="Device to run on (default: gpu).",
-    #                     default="gpu")
 
     parser.add_argument("-q", "--quiet", action="store_true", help="Print no intermediate outputs",
                         default=False)

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -170,7 +170,7 @@ def nnUNetv2_predict(dir_in, dir_out, task_id, model="3d_fullres", folds=None,
     model_folder = get_output_folder(task_id, trainer, plans, model)
 
     assert device in ['cpu', 'cuda',
-                           'mps'], f'-device must be either cpu, mps or cuda. Other devices are not tested/supported. Got: {device}.'
+                           'mps'] or isinstance(device, torch.device), f'-device must be either cpu, mps or cuda. Other devices are not tested/supported. Got: {device}.'
     if device == 'cpu':
         # let's allow torch to use hella threads
         import multiprocessing
@@ -181,6 +181,8 @@ def nnUNetv2_predict(dir_in, dir_out, task_id, model="3d_fullres", folds=None,
         torch.set_num_threads(1)
         # torch.set_num_interop_threads(1)  # throws error if setting the second time
         device = torch.device('cuda')
+    elif isinstance(device, torch.device):
+        device = device
     else:
         device = torch.device('mps')
     disable_tta = not tta

--- a/totalsegmentator/python_api.py
+++ b/totalsegmentator/python_api.py
@@ -67,14 +67,23 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
 
     nora_tag = "None" if nora_tag is None else nora_tag
 
-    if not quiet:
-        print("\nIf you use this tool please cite: https://pubs.rsna.org/doi/10.1148/ryai.230024\n")
 
-    # available devices: gpu | cpu | mps
+    # available devices: gpu | cpu | mps | your desired device id (integer)
     if device == "gpu": device = "cuda"
     if device == "cuda" and not torch.cuda.is_available():
         print("No GPU detected. Running on CPU. This can be very slow. The '--fast' or the `--roi_subset` option can help to reduce runtime.")
         device = "cpu"
+    elif isinstance(device, int):
+        if device < torch.cuda.device_count():
+            device = torch.device(device)
+        else:
+            print("Invalid GPU config, running on the CPU")
+            device = "cpu"
+    print(f"Using Deivce: {device}")
+
+
+    if not quiet:
+        print("\nIf you use this tool please cite: https://pubs.rsna.org/doi/10.1148/ryai.230024\n")
 
     setup_nnunet()
     setup_totalseg()

--- a/totalsegmentator/python_api.py
+++ b/totalsegmentator/python_api.py
@@ -68,13 +68,14 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
     nora_tag = "None" if nora_tag is None else nora_tag
 
 
-    # available devices: gpu | cpu | mps | your desired device id (integer)
+    # available devices: gpu | cpu | mps | gpu:1, gpu:2, etc.
     if device == "gpu": device = "cuda"
     if device == "cuda" and not torch.cuda.is_available():
         print("No GPU detected. Running on CPU. This can be very slow. The '--fast' or the `--roi_subset` option can help to reduce runtime.")
         device = "cpu"
-    elif isinstance(device, int):
-        if device < torch.cuda.device_count():
+    elif device.startswith('cuda:'):
+        device_id = int(device[5:])
+        if device_id < torch.cuda.device_count():
             device = torch.device(device)
         else:
             print("Invalid GPU config, running on the CPU")


### PR DESCRIPTION
Adding GPU selection features and one unit test, and updating the documentation.

For CLI usage:
`TotalSegmentator .... -d gpu:X (e.g. gpu:1 -> cuda:1)`

For Python API:
```python
device = 'gpu:1' # cuda:1
totalsegmentator(input_path, output_path, device=device)
```


