### PR TITLE
Add ROI Mapping for Total and Total_MR Tasks

### DIFF
--- a/resources/totalsegmentator_total_mapping.csv
+++ b/resources/totalsegmentator_total_mapping.csv
@@ -1,0 +1,119 @@
+Index,TotalSegmentator_name,TA2_name
+1,spleen,
+2,kidney_right,
+3,kidney_left,
+4,gallbladder,
+5,liver,
+6,stomach,
+7,pancreas,
+8,adrenal_gland_right,suprarenal gland
+9,adrenal_gland_left,suprarenal gland
+10,lung_upper_lobe_left,superior lobe of left lung
+11,lung_lower_lobe_left,inferior lobe of left lung
+12,lung_upper_lobe_right,superior lobe of right lung
+13,lung_middle_lobe_right,middle lobe of right lung
+14,lung_lower_lobe_right,inferior lobe of right lung
+15,esophagus,
+16,trachea,
+17,thyroid_gland,
+18,small_bowel,small intestine
+19,duodenum,
+20,colon,
+21,urinary_bladder,
+22,prostate,
+23,kidney_cyst_left,
+24,kidney_cyst_right,
+25,sacrum,
+26,vertebrae_S1,
+27,vertebrae_L5,
+28,vertebrae_L4,
+29,vertebrae_L3,
+30,vertebrae_L2,
+31,vertebrae_L1,
+32,vertebrae_T12,
+33,vertebrae_T11,
+34,vertebrae_T10,
+35,vertebrae_T9,
+36,vertebrae_T8,
+37,vertebrae_T7,
+38,vertebrae_T6,
+39,vertebrae_T5,
+40,vertebrae_T4,
+41,vertebrae_T3,
+42,vertebrae_T2,
+43,vertebrae_T1,
+44,vertebrae_C7,
+45,vertebrae_C6,
+46,vertebrae_C5,
+47,vertebrae_C4,
+48,vertebrae_C3,
+49,vertebrae_C2,
+50,vertebrae_C1,
+51,heart,
+52,aorta,
+53,pulmonary_vein,
+54,brachiocephalic_trunk,
+55,subclavian_artery_right,
+56,subclavian_artery_left,
+57,common_carotid_artery_right,
+58,common_carotid_artery_left,
+59,brachiocephalic_vein_left,
+60,brachiocephalic_vein_right,
+61,atrial_appendage_left,
+62,superior_vena_cava,
+63,inferior_vena_cava,
+64,portal_vein_and_splenic_vein,hepatic portal vein
+65,iliac_artery_left,common iliac artery
+66,iliac_artery_right,common iliac artery
+67,iliac_vena_left,common iliac vein
+68,iliac_vena_right,common iliac vein
+69,humerus_left,
+70,humerus_right,
+71,scapula_left,
+72,scapula_right,
+73,clavicula_left,clavicle
+74,clavicula_right,clavicle
+75,femur_left,
+76,femur_right,
+77,hip_left,
+78,hip_right,
+79,spinal_cord,
+80,gluteus_maximus_left,gluteus maximus muscle
+81,gluteus_maximus_right,gluteus maximus muscle
+82,gluteus_medius_left,gluteus medius muscle
+83,gluteus_medius_right,gluteus medius muscle
+84,gluteus_minimus_left,gluteus minimus muscle
+85,gluteus_minimus_right,gluteus minimus muscle
+86,autochthon_left,
+87,autochthon_right,
+88,iliopsoas_left,iliopsoas muscle
+89,iliopsoas_right,iliopsoas muscle
+90,brain,
+91,skull,
+92,rib_left_1,
+93,rib_left_2,
+94,rib_left_3,
+95,rib_left_4,
+96,rib_left_5,
+97,rib_left_6,
+98,rib_left_7,
+99,rib_left_8,
+100,rib_left_9,
+101,rib_left_10,
+102,rib_left_11,
+103,rib_left_12,
+104,rib_right_1,
+105,rib_right_2,
+106,rib_right_3,
+107,rib_right_4,
+108,rib_right_5,
+109,rib_right_6,
+110,rib_right_7,
+111,rib_right_8,
+112,rib_right_9,
+113,rib_right_10,
+114,rib_right_11,
+115,rib_right_12,
+116,sternum,
+117,costal_cartilages,
+

--- a/resources/totalsegmentator_totalmr_mapping.csv
+++ b/resources/totalsegmentator_totalmr_mapping.csv
@@ -1,0 +1,58 @@
+Index,TotalSegmentator_name,TA2_name
+1,spleen,
+2,kidney_right,
+3,kidney_left,
+4,gallbladder,
+5,liver,
+6,stomach,
+7,pancreas,
+8,adrenal_gland_right,suprarenal gland
+9,adrenal_gland_left,suprarenal gland
+10,lung_left,
+11,lung_right,
+12,esophagus,
+13,small_bowel,small intestine
+14,duodenum,
+15,colon,
+16,urinary_bladder,
+17,prostate,
+18,sacrum,
+19,vertebrae,
+20,intervertebral_discs,
+21,spinal_cord,
+22,heart,
+23,aorta,
+24,inferior_vena_cava,
+25,portal_vein_and_splenic_vein,hepatic portal vein
+26,iliac_artery_left,common iliac artery
+27,iliac_artery_right,common iliac artery
+28,iliac_vena_left,common iliac vein
+29,iliac_vena_right,common iliac vein
+30,humerus_left,
+31,humerus_right,
+32,fibula,
+33,tibia,
+34,femur_left,
+35,femur_right,
+36,hip_left,
+37,hip_right,
+38,gluteus_maximus_left,gluteus maximus muscle
+39,gluteus_maximus_right,gluteus maximus muscle
+40,gluteus_medius_left,gluteus medius muscle
+41,gluteus_medius_right,gluteus medius muscle
+42,gluteus_minimus_left,gluteus minimus muscle
+43,gluteus_minimus_right,gluteus minimus muscle
+44,autochthon_left,
+45,autochthon_right,
+46,iliopsoas_left,iliopsoas muscle
+47,iliopsoas_right,iliopsoas muscle
+48,quadriceps_femoris_left,
+49,quadriceps_femoris_right,
+50,thigh_medial_compartment_left,
+51,thigh_medial_compartment_right,
+52,thigh_posterior_compartment_left,
+53,thigh_posterior_compartment_right,
+54,sartorius_left,
+55,sartorius_right,
+56,brain,
+


### PR DESCRIPTION
Hello,

I was looking for the ROI mapping for the NIfTI structures and noticed that the SNOMED-CT mapping was missing. While I came across the existing PR for the new mapping, I thought it would also be helpful to include CSV files for the names used in TotalSegmentator, specifically for the `total` and `total_mr` tasks.

This PR adds the following files to the `resources` folder:

`totalsegmentator_total_mapping.csv` - Contains the mapping of names for the total task.
`totalsegmentator_totalmr_mapping.csv` - Contains the mapping of names for the total_mr task.

These CSV files aim to help users quickly reference the names and their mappings for these tasks.

Thank you for considering this contribution!

Best regards,
Tristan