### PR TITLE
Use docker parameter shm-size=4G instead of ipc=host

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ We provide the following web applications to easily process your images:
 ### Run via docker
 We also provide a docker container which can be used the following way
 ```bash
-docker run --gpus 'device=0' --ipc=host -v /absolute/path/to/my/data/directory:/tmp wasserth/totalsegmentator:2.2.1 TotalSegmentator -i /tmp/ct.nii.gz -o /tmp/segmentations
+docker run --gpus 'device=0' --shm-size=4G -v /absolute/path/to/my/data/directory:/tmp wasserth/totalsegmentator:2.2.1 TotalSegmentator -i /tmp/ct.nii.gz -o /tmp/segmentations
 ```
 
 


### PR DESCRIPTION
PyTorch uses shared memory to exchange data between parallel workers. Docker gives running container a default of 64MB which is fairly small for any meaningful process.

With the parameter `ipc=host` you let the container access the RAM from the host. However it is not protected, and any other container can access it.

Using `--shm-size=4G` docker allocates that memory for the container to shared between the internal processes. Of course you can tune the size according to the payload.