### PR TITLE
Change ruff line-length limit from 550 to 88

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = [
     "venv",
 ]
 
-line-length = 550
+line-length = 88
 indent-width = 4
 target-version = "py39"
 


### PR DESCRIPTION
Ruff expects a line length between 1 and 320 (see error in VS Code Ruff extension below). This commit changes the line-length from 550 to 88, which is ruff's default.

```
[Error - 9:15:13 AM] Server process exited with code 0.
2025-12-10 09:15:13.904638000 ERROR Failed to parse /private/tmp/TotalSegmentator/pyproject.toml: TOML parse error at line 27, column 15
   |
27 | line-length = 550
   |               ^^^
line-length must be between 1 and 320 (got 550)
```