### PR TITLE
Fix radiomics pipeline: swapped arguments and path type error

### DIFF
--- a/totalsegmentator/python_api.py
+++ b/totalsegmentator/python_api.py
@@ -853,7 +853,7 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
         stats_dir = output.parent if ml else output
         with tempfile.TemporaryDirectory(prefix="radiomics_tmp_") as tmp_folder:
             if isinstance(input, Nifti1Image):
-                input_path = tmp_folder / "ct.nii.gz"
+                input_path = Path(tmp_folder) / "ct.nii.gz"
                 nib.save(input, input_path)
             else:
                 input_path = input

--- a/totalsegmentator/statistics.py
+++ b/totalsegmentator/statistics.py
@@ -55,7 +55,7 @@ def get_radiomics_features(seg_file, img_file="ct.nii.gz"):
 
 def get_radiomics_features_for_entire_dir(ct_file:Path, mask_dir:Path, file_out:Path):
     masks = sorted(list(mask_dir.glob("*.nii.gz")))
-    stats = [get_radiomics_features(ct_file, mask) for mask in masks]
+    stats = [get_radiomics_features(mask, ct_file) for mask in masks]
     stats = {mask_name: stats for mask_name, stats in stats}
     with open(file_out, "w") as f:
         json.dump(stats, f, indent=4)


### PR DESCRIPTION
## Summary

- **Swapped CT/mask arguments**: `get_radiomics_features_for_entire_dir()` in `statistics.py` passed `ct_file` as the first argument to `get_radiomics_features()`, but the function signature is `(seg_file, img_file)`. This reversed the CT and mask roles, producing incorrect radiomics features and keying all results under the CT filename instead of individual mask names.
- **TypeError on TemporaryDirectory path**: In `python_api.py`, `tempfile.TemporaryDirectory()` returns a `str`, but the code used the `/` operator on it (`tmp_folder / "ct.nii.gz"`), which raises `TypeError` when radiomics is called on a `Nifti1Image` input. Wrapped with `Path()` to fix.

Both bugs make the radiomics pipeline (`--radiomics` flag) non-functional.

## Test plan

- [ ] Run `totalsegmentator` with `--radiomics` flag on a nifti input and verify features are computed per-mask
- [ ] Run with a `Nifti1Image` object via the Python API with `radiomics=True` and verify no `TypeError`
- [ ] Verify `statistics_radiomics.json` keys are mask names (e.g., `liver`, `spleen`) not the CT filename