### PR TITLE
Fix get_basic_statistics() to always return stats

### DIFF
--- a/totalsegmentator/statistics.py
+++ b/totalsegmentator/statistics.py
@@ -137,5 +137,5 @@ def get_basic_statistics(seg: np.array,
         # For other people csv might be better -> not really because here only for one subject each -> use json
         with open(file_out, "w") as f:
             json.dump(stats, f, indent=4)
-    else:
-        return stats
+
+    return stats


### PR DESCRIPTION
## Summary

- `get_basic_statistics()` only returned `stats` when `file_out` was `None`. When `file_out` was provided, it wrote the JSON file but fell through without returning, so callers received `None`.
- This affects the Python API: `totalsegmentator(..., statistics=True)` returns `(seg_img, None)` whenever an output path is set, silently discarding computed statistics.
- Fix: return `stats` unconditionally, regardless of whether `file_out` is set.

## Test plan

- [ ] Call `totalsegmentator()` via Python API with `statistics=True` and an output path — verify the returned tuple contains the stats dict, not `None`
- [ ] Verify `statistics.json` is still written to disk when output path is provided
- [ ] Verify stats are still returned when no output path is given (existing behavior preserved)