### PR TITLE
Fix nostdout() to restore sys.stdout after exceptions

### DIFF
--- a/totalsegmentator/libs.py
+++ b/totalsegmentator/libs.py
@@ -33,8 +33,10 @@ def nostdout(verbose=False):
     if not verbose:
         save_stdout = sys.stdout
         sys.stdout = DummyFile()
-        yield
-        sys.stdout = save_stdout
+        try:
+            yield
+        finally:
+            sys.stdout = save_stdout
     else:
         yield
 


### PR DESCRIPTION
## Summary

- `nostdout()` context manager replaced `sys.stdout` with a `DummyFile` but only restored it on normal exit. If an exception was raised during the `yield` (e.g., a failing nnU-Net prediction), `sys.stdout` remained permanently suppressed for the rest of the process.
- This is used around inference calls in `nnunet.py` (lines 565 and 592), so a prediction failure could leave the process mute — no further `print()` output would be visible.
- Fix: wrap the `yield` in `try/finally` to guarantee `sys.stdout` is restored.

## Test plan

- [ ] Trigger a prediction error within a `nostdout()` block and verify that subsequent `print()` calls produce output
- [ ] Verify normal (non-error) prediction still suppresses stdout as intended