### PR TITLE
Fix NameError in undo_canonical_nifti()

### DIFF
--- a/totalsegmentator/alignment.py
+++ b/totalsegmentator/alignment.py
@@ -47,7 +47,7 @@ def undo_canonical(img_can, img_orig):
 
 
 def undo_canonical_nifti(path_in_can, path_in_orig, path_out):
-    e = nib.load(path_in_can)
+    img_can = nib.load(path_in_can)
     img_orig = nib.load(path_in_orig)
     img_out = undo_canonical(img_can, img_orig)
     nib.save(img_out, path_out)


### PR DESCRIPTION
## Summary

- `undo_canonical_nifti()` in `alignment.py` loads the canonical image into a variable named `e`, but the next line references `img_can`, which is undefined. This causes a `NameError` on every call.
- Fix: rename `e` to `img_can` to match the variable name used in the `undo_canonical()` call.

## Test plan

- [ ] Call `undo_canonical_nifti()` with valid canonical and original nifti paths and verify it completes without error
- [ ] Verify the output image has the expected orientation matching the original