### PR TITLE
Fix get_basic_statistics() path type check

### DIFF
--- a/totalsegmentator/statistics.py
+++ b/totalsegmentator/statistics.py
@@ -100,7 +100,7 @@ def get_basic_statistics(seg: np.array,
     """
     ct_file: path to a ct_file or a nifti file object
     """
-    ct_img = nib.load(ct_file) if type(ct_file) == pathlib.PosixPath else ct_file
+    ct_img = nib.load(ct_file) if isinstance(ct_file, (str, Path)) else ct_file
     ct = ct_img.get_fdata().astype(np.int16)
     spacing = ct_img.header.get_zooms()
     vox_vol = spacing[0] * spacing[1] * spacing[2]


### PR DESCRIPTION
## Summary

- `get_basic_statistics()` used `type(ct_file) == pathlib.PosixPath` to decide whether to load from disk. This exact type check fails for string paths, `WindowsPath`, and other `PathLike` inputs — they fall through to the `else` branch which treats them as a Nifti1Image, causing an `AttributeError` on `.get_fdata()`.
- Fix: use `isinstance(ct_file, (str, Path))` to match all common path types. `Path` covers both `PosixPath` and `WindowsPath`, and `str` covers plain string paths.

## Test plan

- [ ] Call `get_basic_statistics()` with a string path and verify it loads correctly
- [ ] Call with a `Path` object and verify it loads correctly
- [ ] Call with a `Nifti1Image` object and verify it uses the object directly