### PR TITLE
Fix split sub-volume affine origins for s02 and s03

### DIFF
--- a/tests/mock_imports.py
+++ b/tests/mock_imports.py
@@ -1,0 +1,57 @@
+"""
+Context manager for importing modules that have heavy/unavailable dependencies.
+
+Usage:
+
+    from tests.mock_imports import mock_imports
+
+    with mock_imports("torch", "nnunetv2", "totalsegmentator.libs") as ctx:
+        from totalsegmentator.nnunet import split_image_into_parts
+
+    # sys.modules is fully restored here.
+    # ctx.mocked_names  — set of all module names that were mocked or added
+    # ctx.snapshot       — sys.modules keys before mocking
+
+The imported names (split_image_into_parts, etc.) remain usable after the
+context manager exits because they're bound in the caller's namespace.
+"""
+
+import sys
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+@contextmanager
+def mock_imports(*module_names):
+    """Temporarily inject MagicMock entries into sys.modules for the listed
+    module names, yield, then restore sys.modules to its pre-mock state.
+
+    Any modules added to sys.modules during the yield (e.g. transitive
+    imports triggered by the caller's ``from X import Y``) are also removed,
+    preventing test pollution.
+
+    Yields a SimpleNamespace with:
+        .mocked_names  — set of all module names that were mocked or added
+        .snapshot       — frozenset of sys.modules keys before mocking
+    """
+    snapshot = frozenset(sys.modules.keys())
+    saved = {}
+    for name in module_names:
+        saved[name] = sys.modules.get(name)
+        if name not in sys.modules:
+            sys.modules[name] = MagicMock()
+
+    ctx = SimpleNamespace(mocked_names=set(), snapshot=snapshot)
+    try:
+        yield ctx
+    finally:
+        # Remove everything added during the yield (transitive imports too)
+        added = set(sys.modules.keys()) - snapshot
+        for name in added:
+            del sys.modules[name]
+        # Reinstate anything that existed before mocking
+        for name, orig in saved.items():
+            if orig is not None:
+                sys.modules[name] = orig
+        ctx.mocked_names = set(module_names) | added

--- a/tests/test_mock_imports.py
+++ b/tests/test_mock_imports.py
@@ -1,0 +1,49 @@
+"""Tests for the mock_imports context manager itself."""
+
+import sys
+import pytest
+from tests.mock_imports import mock_imports
+
+
+class TestMockImports:
+
+    def test_mocks_injected_during_context(self):
+        """Modules should be available in sys.modules inside the with block."""
+        with mock_imports("fake_module_abc", "fake_module_xyz"):
+            assert "fake_module_abc" in sys.modules
+            assert "fake_module_xyz" in sys.modules
+
+    def test_mocks_removed_after_context(self):
+        """Mocked modules should not remain in sys.modules after exit."""
+        with mock_imports("fake_module_abc"):
+            pass
+        assert "fake_module_abc" not in sys.modules
+
+    def test_preexisting_module_untouched(self):
+        """A module already in sys.modules should not be replaced by a mock."""
+        original = sys.modules["os"]
+        with mock_imports("os"):
+            assert sys.modules["os"] is original
+        assert sys.modules["os"] is original
+
+    def test_transitive_imports_cleaned(self):
+        """Modules added during the yield (not in the mock list) are also removed."""
+        import types
+        with mock_imports("fake_parent") as ctx:
+            # Simulate a transitive import that happens during the yield
+            sys.modules["fake_parent.child"] = types.ModuleType("fake_parent.child")
+        assert "fake_parent" not in sys.modules
+        assert "fake_parent.child" not in sys.modules
+        assert "fake_parent.child" in ctx.mocked_names
+
+    def test_ctx_snapshot_is_frozen(self):
+        """The snapshot should reflect sys.modules state before mocking."""
+        before = frozenset(sys.modules.keys())
+        with mock_imports("fake_module_abc") as ctx:
+            assert ctx.snapshot == before
+
+    def test_ctx_mocked_names_populated(self):
+        """mocked_names should include both explicit mocks and transitive additions."""
+        with mock_imports("fake_module_abc") as ctx:
+            pass
+        assert "fake_module_abc" in ctx.mocked_names

--- a/tests/test_split_affine.py
+++ b/tests/test_split_affine.py
@@ -1,0 +1,200 @@
+"""
+Tests that triple-split sub-volumes get correct affine origins and that
+reassembly recovers the original data and affine.
+
+These tests exercise the split/merge logic from nnunet.py without
+requiring nnU-Net or GPU inference.
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import nibabel as nib
+import pytest
+
+
+def make_test_image(shape=(64, 64, 300), voxel_size=(1.5, 1.5, 1.5)):
+    """Create a synthetic nifti image with a non-trivial affine."""
+    affine = np.eye(4)
+    affine[0, 0] = voxel_size[0]
+    affine[1, 1] = voxel_size[1]
+    affine[2, 2] = voxel_size[2]
+    # Non-zero origin
+    affine[:3, 3] = [-48.0, -48.0, -225.0]
+    data = np.random.randint(0, 100, shape, dtype=np.int16)
+    return nib.Nifti1Image(data, affine), data
+
+
+def make_rotated_test_image(shape=(64, 64, 300)):
+    """Create a synthetic nifti image with off-diagonal rotation in the affine."""
+    # ~15 degree rotation around the y-axis
+    angle = np.radians(15)
+    affine = np.eye(4)
+    affine[0, 0] = 1.5 * np.cos(angle)
+    affine[0, 2] = 1.5 * np.sin(angle)
+    affine[1, 1] = 1.5
+    affine[2, 0] = -1.5 * np.sin(angle)
+    affine[2, 2] = 1.5 * np.cos(angle)
+    affine[:3, 3] = [-48.0, -48.0, -225.0]
+    data = np.random.randint(0, 100, shape, dtype=np.int16)
+    return nib.Nifti1Image(data, affine), data
+
+
+def split_image(img, tmp_dir):
+    """Replicate the triple-split logic from nnunet.py with corrected affines."""
+    third = img.shape[2] // 3
+    margin = 20
+    data = img.get_fdata()
+    base_affine = img.affine
+
+    s02_start = third + 1 - margin
+    s03_start = third * 2 + 1 - margin
+
+    affine_s02 = np.copy(base_affine)
+    affine_s02[:3, 3] = base_affine[:3, 3] + s02_start * base_affine[:3, 2]
+
+    affine_s03 = np.copy(base_affine)
+    affine_s03[:3, 3] = base_affine[:3, 3] + s03_start * base_affine[:3, 2]
+
+    parts = {
+        "s01": nib.Nifti1Image(data[:, :, :third + margin], base_affine),
+        "s02": nib.Nifti1Image(data[:, :, s02_start:third * 2 + margin], affine_s02),
+        "s03": nib.Nifti1Image(data[:, :, s03_start:], affine_s03),
+    }
+
+    for name, part_img in parts.items():
+        nib.save(part_img, tmp_dir / f"{name}_0000.nii.gz")
+
+    return parts, third, margin
+
+
+def reassemble(tmp_dir, original_shape, original_affine, third, margin):
+    """Replicate the reassembly logic from nnunet.py."""
+    combined = np.zeros(original_shape, dtype=np.int16)
+    combined[:, :, :third] = nib.load(tmp_dir / "s01_0000.nii.gz").get_fdata()[:, :, :-margin]
+    combined[:, :, third:third * 2] = nib.load(tmp_dir / "s02_0000.nii.gz").get_fdata()[:, :, margin - 1:-margin]
+    combined[:, :, third * 2:] = nib.load(tmp_dir / "s03_0000.nii.gz").get_fdata()[:, :, margin - 1:]
+    return nib.Nifti1Image(combined, original_affine)
+
+
+class TestSplitAffineOrigins:
+    """Verify that each sub-volume's affine origin maps voxel (0,0,0) to the
+    correct world coordinate."""
+
+    def test_s01_origin_unchanged(self):
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            parts, _, _ = split_image(img, tmp_dir)
+            np.testing.assert_array_equal(
+                parts["s01"].affine[:3, 3],
+                img.affine[:3, 3],
+                err_msg="s01 origin should match the original image origin",
+            )
+
+    def test_s02_origin_shifted(self):
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            parts, third, margin = split_image(img, tmp_dir)
+            s02_start = third + 1 - margin
+            expected_origin = img.affine[:3, 3] + s02_start * img.affine[:3, 2]
+            np.testing.assert_array_almost_equal(
+                parts["s02"].affine[:3, 3],
+                expected_origin,
+                err_msg="s02 origin should be shifted by s02_start voxels along z",
+            )
+
+    def test_s03_origin_shifted(self):
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            parts, third, margin = split_image(img, tmp_dir)
+            s03_start = third * 2 + 1 - margin
+            expected_origin = img.affine[:3, 3] + s03_start * img.affine[:3, 2]
+            np.testing.assert_array_almost_equal(
+                parts["s03"].affine[:3, 3],
+                expected_origin,
+                err_msg="s03 origin should be shifted by s03_start voxels along z",
+            )
+
+    def test_voxel_to_world_consistency(self):
+        """Voxel (0,0,0) of each sub-volume should map to the world coordinate
+        of its starting slice in the original image."""
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            parts, third, margin = split_image(img, tmp_dir)
+
+            starts = {"s01": 0, "s02": third + 1 - margin, "s03": third * 2 + 1 - margin}
+            for name, start_z in starts.items():
+                # World coord of voxel (0,0,0) in the sub-volume
+                part_world = parts[name].affine @ np.array([0, 0, 0, 1])
+                # World coord of voxel (0, 0, start_z) in the original
+                orig_world = img.affine @ np.array([0, 0, start_z, 1])
+                np.testing.assert_array_almost_equal(
+                    part_world[:3],
+                    orig_world[:3],
+                    err_msg=f"{name} voxel (0,0,0) should map to original voxel (0,0,{start_z})",
+                )
+
+    def test_rotated_affine_origins(self):
+        """Affine origin correction should work with off-diagonal rotations."""
+        img, _ = make_rotated_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            parts, third, margin = split_image(img, tmp_dir)
+
+            starts = {"s01": 0, "s02": third + 1 - margin, "s03": third * 2 + 1 - margin}
+            for name, start_z in starts.items():
+                part_world = parts[name].affine @ np.array([0, 0, 0, 1])
+                orig_world = img.affine @ np.array([0, 0, start_z, 1])
+                np.testing.assert_array_almost_equal(
+                    part_world[:3],
+                    orig_world[:3],
+                    err_msg=f"{name} origin wrong with rotated affine",
+                )
+
+
+class TestSplitReassembly:
+    """Verify that split + reassemble recovers the original data."""
+
+    def test_roundtrip_data_integrity(self):
+        img, original_data = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            _, third, margin = split_image(img, tmp_dir)
+            reassembled = reassemble(tmp_dir, img.shape, img.affine, third, margin)
+            np.testing.assert_array_equal(
+                reassembled.get_fdata().astype(np.int16),
+                original_data,
+                err_msg="Reassembled data should exactly match the original",
+            )
+
+    def test_roundtrip_affine_preserved(self):
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            _, third, margin = split_image(img, tmp_dir)
+            reassembled = reassemble(tmp_dir, img.shape, img.affine, third, margin)
+            np.testing.assert_array_equal(
+                reassembled.affine,
+                img.affine,
+                err_msg="Reassembled affine should match the original",
+            )
+
+    def test_parts_saved_to_disk_have_correct_affines(self):
+        """Verify that the nifti files on disk (not just in-memory) have correct affines."""
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            parts, third, margin = split_image(img, tmp_dir)
+
+            for name in ["s01", "s02", "s03"]:
+                loaded = nib.load(tmp_dir / f"{name}_0000.nii.gz")
+                np.testing.assert_array_almost_equal(
+                    loaded.affine,
+                    parts[name].affine,
+                    err_msg=f"{name} affine on disk doesn't match expected",
+                )

--- a/tests/test_split_affine.py
+++ b/tests/test_split_affine.py
@@ -1,17 +1,45 @@
 """
-Tests that triple-split sub-volumes get correct affine origins and that
-reassembly recovers the original data and affine.
+Tests for the triple-split sub-volume logic extracted into
+split_image_into_parts(), save_merged_predictions(), and reassemble_image()
+in totalsegmentator/nnunet.py.
 
-These tests exercise the split/merge logic from nnunet.py without
-requiring nnU-Net or GPU inference.
+These call the actual production functions, not local reimplementations.
+No nnU-Net or GPU required — heavy dependencies are mocked at import time.
 """
 
+import sys
 import tempfile
 from pathlib import Path
 
 import numpy as np
 import nibabel as nib
 import pytest
+
+from tests.mock_imports import mock_imports
+
+# Modules to mock so we can import totalsegmentator.nnunet without
+# torch, nnunetv2, or other heavy deps.
+_MOCK_MODULES = [
+    "torch", "torch.cuda", "torch.backends", "torch.backends.cudnn",
+    "nnunetv2", "nnunetv2.utilities", "nnunetv2.utilities.find_class_by_name",
+    "nnunetv2.utilities.file_path_utilities",
+    "nnunetv2.inference", "nnunetv2.inference.predict_from_raw_data",
+    "SimpleITK", "xvfbwrapper", "dicom2nifti", "pyarrow", "xmltodict",
+    "rt_utils", "pydicom", "cv2",
+    "totalsegmentator.custom_trainers",
+    "totalsegmentator.libs",
+    "totalsegmentator.config",
+    "totalsegmentator.dicom_io",
+    "totalsegmentator.postprocessing",
+    "totalsegmentator.cropping",
+]
+
+with mock_imports(*_MOCK_MODULES) as _mock_ctx:
+    from totalsegmentator.nnunet import (
+        split_image_into_parts,
+        save_merged_predictions,
+        reassemble_image,
+    )
 
 
 def make_test_image(shape=(64, 64, 300), voxel_size=(1.5, 1.5, 1.5)):
@@ -20,7 +48,6 @@ def make_test_image(shape=(64, 64, 300), voxel_size=(1.5, 1.5, 1.5)):
     affine[0, 0] = voxel_size[0]
     affine[1, 1] = voxel_size[1]
     affine[2, 2] = voxel_size[2]
-    # Non-zero origin
     affine[:3, 3] = [-48.0, -48.0, -225.0]
     data = np.random.randint(0, 100, shape, dtype=np.int16)
     return nib.Nifti1Image(data, affine), data
@@ -28,7 +55,6 @@ def make_test_image(shape=(64, 64, 300), voxel_size=(1.5, 1.5, 1.5)):
 
 def make_rotated_test_image(shape=(64, 64, 300)):
     """Create a synthetic nifti image with off-diagonal rotation in the affine."""
-    # ~15 degree rotation around the y-axis
     angle = np.radians(15)
     affine = np.eye(4)
     affine[0, 0] = 1.5 * np.cos(angle)
@@ -41,54 +67,16 @@ def make_rotated_test_image(shape=(64, 64, 300)):
     return nib.Nifti1Image(data, affine), data
 
 
-def split_image(img, tmp_dir):
-    """Replicate the triple-split logic from nnunet.py with corrected affines."""
-    third = img.shape[2] // 3
-    margin = 20
-    data = img.get_fdata()
-    base_affine = img.affine
-
-    s02_start = third + 1 - margin
-    s03_start = third * 2 + 1 - margin
-
-    affine_s02 = np.copy(base_affine)
-    affine_s02[:3, 3] = base_affine[:3, 3] + s02_start * base_affine[:3, 2]
-
-    affine_s03 = np.copy(base_affine)
-    affine_s03[:3, 3] = base_affine[:3, 3] + s03_start * base_affine[:3, 2]
-
-    parts = {
-        "s01": nib.Nifti1Image(data[:, :, :third + margin], base_affine),
-        "s02": nib.Nifti1Image(data[:, :, s02_start:third * 2 + margin], affine_s02),
-        "s03": nib.Nifti1Image(data[:, :, s03_start:], affine_s03),
-    }
-
-    for name, part_img in parts.items():
-        nib.save(part_img, tmp_dir / f"{name}_0000.nii.gz")
-
-    return parts, third, margin
-
-
-def reassemble(tmp_dir, original_shape, original_affine, third, margin):
-    """Replicate the reassembly logic from nnunet.py."""
-    combined = np.zeros(original_shape, dtype=np.int16)
-    combined[:, :, :third] = nib.load(tmp_dir / "s01_0000.nii.gz").get_fdata()[:, :, :-margin]
-    combined[:, :, third:third * 2] = nib.load(tmp_dir / "s02_0000.nii.gz").get_fdata()[:, :, margin - 1:-margin]
-    combined[:, :, third * 2:] = nib.load(tmp_dir / "s03_0000.nii.gz").get_fdata()[:, :, margin - 1:]
-    return nib.Nifti1Image(combined, original_affine)
-
-
-class TestSplitAffineOrigins:
-    """Verify that each sub-volume's affine origin maps voxel (0,0,0) to the
-    correct world coordinate."""
+class TestSplitImageIntoParts:
+    """Tests for split_image_into_parts() — the production split function."""
 
     def test_s01_origin_unchanged(self):
         img, _ = make_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            parts, _, _ = split_image(img, tmp_dir)
+            _, part_affines, _, _ = split_image_into_parts(img, tmp_dir)
             np.testing.assert_array_equal(
-                parts["s01"].affine[:3, 3],
+                part_affines["s01"][:3, 3],
                 img.affine[:3, 3],
                 err_msg="s01 origin should match the original image origin",
             )
@@ -97,11 +85,11 @@ class TestSplitAffineOrigins:
         img, _ = make_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            parts, third, margin = split_image(img, tmp_dir)
+            _, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
             s02_start = third + 1 - margin
             expected_origin = img.affine[:3, 3] + s02_start * img.affine[:3, 2]
             np.testing.assert_array_almost_equal(
-                parts["s02"].affine[:3, 3],
+                part_affines["s02"][:3, 3],
                 expected_origin,
                 err_msg="s02 origin should be shifted by s02_start voxels along z",
             )
@@ -110,11 +98,11 @@ class TestSplitAffineOrigins:
         img, _ = make_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            parts, third, margin = split_image(img, tmp_dir)
+            _, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
             s03_start = third * 2 + 1 - margin
             expected_origin = img.affine[:3, 3] + s03_start * img.affine[:3, 2]
             np.testing.assert_array_almost_equal(
-                parts["s03"].affine[:3, 3],
+                part_affines["s03"][:3, 3],
                 expected_origin,
                 err_msg="s03 origin should be shifted by s03_start voxels along z",
             )
@@ -125,13 +113,11 @@ class TestSplitAffineOrigins:
         img, _ = make_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            parts, third, margin = split_image(img, tmp_dir)
+            _, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
 
             starts = {"s01": 0, "s02": third + 1 - margin, "s03": third * 2 + 1 - margin}
             for name, start_z in starts.items():
-                # World coord of voxel (0,0,0) in the sub-volume
-                part_world = parts[name].affine @ np.array([0, 0, 0, 1])
-                # World coord of voxel (0, 0, start_z) in the original
+                part_world = part_affines[name] @ np.array([0, 0, 0, 1])
                 orig_world = img.affine @ np.array([0, 0, start_z, 1])
                 np.testing.assert_array_almost_equal(
                     part_world[:3],
@@ -144,11 +130,11 @@ class TestSplitAffineOrigins:
         img, _ = make_rotated_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            parts, third, margin = split_image(img, tmp_dir)
+            _, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
 
             starts = {"s01": 0, "s02": third + 1 - margin, "s03": third * 2 + 1 - margin}
             for name, start_z in starts.items():
-                part_world = parts[name].affine @ np.array([0, 0, 0, 1])
+                part_world = part_affines[name] @ np.array([0, 0, 0, 1])
                 orig_world = img.affine @ np.array([0, 0, start_z, 1])
                 np.testing.assert_array_almost_equal(
                     part_world[:3],
@@ -156,45 +142,133 @@ class TestSplitAffineOrigins:
                     err_msg=f"{name} origin wrong with rotated affine",
                 )
 
+    def test_parts_saved_to_disk_have_correct_affines(self):
+        """Verify nifti files on disk have the correct affines."""
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            _, part_affines, _, _ = split_image_into_parts(img, tmp_dir)
 
-class TestSplitReassembly:
-    """Verify that split + reassemble recovers the original data."""
+            for name in ["s01", "s02", "s03"]:
+                loaded = nib.load(tmp_dir / f"{name}_0000.nii.gz")
+                np.testing.assert_array_almost_equal(
+                    loaded.affine,
+                    part_affines[name],
+                    err_msg=f"{name} affine on disk doesn't match expected",
+                )
+
+
+class TestSaveMergedPredictions:
+    """Tests for save_merged_predictions() — the production merge function.
+
+    This is the code path that previously overwrote corrected affines with
+    the base affine, which was the actual regression.
+    """
+
+    def test_merged_outputs_have_correct_affines(self):
+        """The specific regression: merged s02/s03 must retain shifted affines."""
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            img_parts, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
+
+            seg_combined = {}
+            for name in img_parts:
+                shape = nib.load(tmp_dir / f"{name}_0000.nii.gz").shape
+                seg_combined[name] = np.ones(shape, dtype=np.uint8)
+
+            save_merged_predictions(seg_combined, img_parts, part_affines,
+                                    do_triple_split=True, base_affine=img.affine,
+                                    tmp_dir=tmp_dir)
+
+            for name in img_parts:
+                loaded = nib.load(tmp_dir / f"{name}.nii.gz")
+                np.testing.assert_array_almost_equal(
+                    loaded.affine,
+                    part_affines[name],
+                    err_msg=f"Merged {name}.nii.gz has wrong affine — "
+                            f"regression: merge overwrote corrected origin",
+                )
+
+    def test_non_split_uses_base_affine(self):
+        """When do_triple_split is False, all parts use the base affine."""
+        img, _ = make_test_image()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            seg_combined = {"s01": np.ones(img.shape, dtype=np.uint8)}
+
+            save_merged_predictions(seg_combined, ["s01"], part_affines=None,
+                                    do_triple_split=False, base_affine=img.affine,
+                                    tmp_dir=tmp_dir)
+
+            loaded = nib.load(tmp_dir / "s01.nii.gz")
+            np.testing.assert_array_almost_equal(
+                loaded.affine,
+                img.affine,
+                err_msg="Non-split path should use base affine",
+            )
+
+
+class TestReassembleImage:
+    """Tests for reassemble_image() — the production reassembly function."""
 
     def test_roundtrip_data_integrity(self):
+        """split → save merged → reassemble should recover original data."""
         img, original_data = make_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            _, third, margin = split_image(img, tmp_dir)
-            reassembled = reassemble(tmp_dir, img.shape, img.affine, third, margin)
+            img_parts, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
+
+            seg_combined = {}
+            for name in img_parts:
+                seg_combined[name] = nib.load(tmp_dir / f"{name}_0000.nii.gz").get_fdata().astype(np.uint8)
+
+            save_merged_predictions(seg_combined, img_parts, part_affines,
+                                    do_triple_split=True, base_affine=img.affine,
+                                    tmp_dir=tmp_dir)
+
+            reassembled = reassemble_image(tmp_dir, img.shape, img.affine, third, margin)
             np.testing.assert_array_equal(
                 reassembled.get_fdata().astype(np.int16),
-                original_data,
-                err_msg="Reassembled data should exactly match the original",
+                original_data.astype(np.uint8).astype(np.int16),
+                err_msg="Reassembled data should match the original (modulo dtype)",
             )
 
     def test_roundtrip_affine_preserved(self):
         img, _ = make_test_image()
         with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
-            _, third, margin = split_image(img, tmp_dir)
-            reassembled = reassemble(tmp_dir, img.shape, img.affine, third, margin)
+            img_parts, part_affines, third, margin = split_image_into_parts(img, tmp_dir)
+
+            seg_combined = {}
+            for name in img_parts:
+                seg_combined[name] = nib.load(tmp_dir / f"{name}_0000.nii.gz").get_fdata().astype(np.uint8)
+
+            save_merged_predictions(seg_combined, img_parts, part_affines,
+                                    do_triple_split=True, base_affine=img.affine,
+                                    tmp_dir=tmp_dir)
+
+            reassembled = reassemble_image(tmp_dir, img.shape, img.affine, third, margin)
             np.testing.assert_array_equal(
                 reassembled.affine,
                 img.affine,
                 err_msg="Reassembled affine should match the original",
             )
 
-    def test_parts_saved_to_disk_have_correct_affines(self):
-        """Verify that the nifti files on disk (not just in-memory) have correct affines."""
-        img, _ = make_test_image()
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_dir = Path(tmp)
-            parts, third, margin = split_image(img, tmp_dir)
 
-            for name in ["s01", "s02", "s03"]:
-                loaded = nib.load(tmp_dir / f"{name}_0000.nii.gz")
-                np.testing.assert_array_almost_equal(
-                    loaded.affine,
-                    parts[name].affine,
-                    err_msg=f"{name} affine on disk doesn't match expected",
-                )
+class TestMockCleanup:
+    """Verify that mock_imports() restored sys.modules properly."""
+
+    def test_mocked_modules_not_in_sys_modules(self):
+        """No mocked module should remain in sys.modules after cleanup."""
+        leaked = [
+            name for name in _mock_ctx.mocked_names
+            if name in sys.modules and name not in _mock_ctx.snapshot
+        ]
+        assert leaked == [], f"Mocked modules leaked into sys.modules: {leaked}"
+
+    def test_totalsegmentator_nnunet_not_cached(self):
+        """totalsegmentator.nnunet should not remain cached under mocked deps."""
+        assert "totalsegmentator.nnunet" not in sys.modules or \
+               "totalsegmentator.nnunet" in _mock_ctx.snapshot, \
+               "totalsegmentator.nnunet is cached in sys.modules from mocked import"

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -312,6 +312,55 @@ def nnUNetv2_predict(dir_in, dir_out, task_id, model="3d_fullres", folds=None,
     # nib.save(nib.Nifti1Image(seg.astype(np.uint8), affine), Path(dir_out) / "s01.nii.gz")
 
 
+def split_image_into_parts(img, tmp_dir, margin=20):
+    """Split a nifti image into 3 overlapping parts along the z-axis.
+
+    Returns (img_parts, part_affines, third, margin) where img_parts is
+    ["s01", "s02", "s03"] and part_affines maps each name to its affine.
+    Saves the parts as {name}_0000.nii.gz in tmp_dir.
+    """
+    img_parts = ["s01", "s02", "s03"]
+    third = img.shape[2] // 3
+    data = img.get_fdata()
+    base_affine = img.affine
+
+    s02_start = third + 1 - margin
+    s03_start = third * 2 + 1 - margin
+
+    affine_s02 = np.copy(base_affine)
+    affine_s02[:3, 3] = base_affine[:3, 3] + s02_start * base_affine[:3, 2]
+
+    affine_s03 = np.copy(base_affine)
+    affine_s03[:3, 3] = base_affine[:3, 3] + s03_start * base_affine[:3, 2]
+
+    part_affines = {"s01": base_affine, "s02": affine_s02, "s03": affine_s03}
+
+    nib.save(nib.Nifti1Image(data[:, :, :third + margin], base_affine),
+             tmp_dir / "s01_0000.nii.gz")
+    nib.save(nib.Nifti1Image(data[:, :, s02_start:third * 2 + margin], affine_s02),
+             tmp_dir / "s02_0000.nii.gz")
+    nib.save(nib.Nifti1Image(data[:, :, s03_start:], affine_s03),
+             tmp_dir / "s03_0000.nii.gz")
+
+    return img_parts, part_affines, third, margin
+
+
+def save_merged_predictions(seg_combined, img_parts, part_affines, do_triple_split, base_affine, tmp_dir):
+    """Save merged per-part predictions with correct affines."""
+    for img_part in img_parts:
+        part_aff = part_affines[img_part] if do_triple_split else base_affine
+        nib.save(nib.Nifti1Image(seg_combined[img_part], part_aff), tmp_dir / f"{img_part}.nii.gz")
+
+
+def reassemble_image(tmp_dir, original_shape, original_affine, third, margin):
+    """Reassemble triple-split sub-volumes back into a single image."""
+    combined_img = np.zeros(original_shape, dtype=np.uint8)
+    combined_img[:, :, :third] = nib.load(tmp_dir / "s01.nii.gz").get_fdata()[:, :, :-margin]
+    combined_img[:, :, third:third * 2] = nib.load(tmp_dir / "s02.nii.gz").get_fdata()[:, :, margin - 1:-margin]
+    combined_img[:, :, third * 2:] = nib.load(tmp_dir / "s03.nii.gz").get_fdata()[:, :, margin - 1:]
+    return nib.Nifti1Image(combined_img, original_affine)
+
+
 def save_segmentation_nifti(class_map_item, tmp_dir=None, file_out=None, nora_tag=None, header=None, task_name=None, quiet=None):
     k, v = class_map_item
     # Have to load img inside of each thread. If passing it as argument a lot slower.
@@ -513,29 +562,7 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
             do_triple_split = False
         if do_triple_split:
             if not quiet: print("Splitting into subparts...")
-            img_parts = ["s01", "s02", "s03"]
-            third = img_in_rsp.shape[2] // 3
-            margin = 20  # set margin with fixed values to avoid rounding problem if using percentage of third
-            img_in_rsp_data = img_in_rsp.get_fdata()
-            base_affine = img_in_rsp.affine
-
-            s02_start = third + 1 - margin
-            s03_start = third * 2 + 1 - margin
-
-            affine_s02 = np.copy(base_affine)
-            affine_s02[:3, 3] = base_affine[:3, 3] + s02_start * base_affine[:3, 2]
-
-            affine_s03 = np.copy(base_affine)
-            affine_s03[:3, 3] = base_affine[:3, 3] + s03_start * base_affine[:3, 2]
-
-            part_affines = {"s01": base_affine, "s02": affine_s02, "s03": affine_s03}
-
-            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, :third+margin], base_affine),
-                    tmp_dir / "s01_0000.nii.gz")
-            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, s02_start:third*2+margin], affine_s02),
-                    tmp_dir / "s02_0000.nii.gz")
-            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, s03_start:], affine_s03),
-                    tmp_dir / "s03_0000.nii.gz")
+            img_parts, part_affines, third, margin = split_image_into_parts(img_in_rsp, tmp_dir)
 
         if task_name == "total" and resample is not None and resample[0] < 3.0:
             # overall speedup for 15mm model roughly 11% (GPU) and 100% (CPU)
@@ -593,9 +620,9 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
                         for jdx, class_name in class_map_parts[map_taskid_to_partname[tid]].items():
                             seg_combined[img_part][seg == jdx] = class_map_inv[class_name]
                 # iterate over subparts of image
-                for img_part in img_parts:
-                    part_aff = part_affines[img_part] if do_triple_split else img_in_rsp.affine
-                    nib.save(nib.Nifti1Image(seg_combined[img_part], part_aff), tmp_dir / f"{img_part}.nii.gz")
+                save_merged_predictions(seg_combined, img_parts,
+                                        part_affines if do_triple_split else None,
+                                        do_triple_split, img_in_rsp.affine, tmp_dir)
             elif test == 1:
                 print("WARNING: Using reference seg instead of prediction for testing.")
                 shutil.copy(Path("tests") / "reference_files" / "example_seg.nii.gz", tmp_dir / "s01.nii.gz")
@@ -624,11 +651,8 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
 
         # Combine image subparts back to one image
         if do_triple_split:
-            combined_img = np.zeros(img_in_rsp.shape, dtype=np.uint8)
-            combined_img[:,:,:third] = nib.load(tmp_dir / "s01.nii.gz").get_fdata()[:,:,:-margin]
-            combined_img[:,:,third:third*2] = nib.load(tmp_dir / "s02.nii.gz").get_fdata()[:,:,margin-1:-margin]
-            combined_img[:,:,third*2:] = nib.load(tmp_dir / "s03.nii.gz").get_fdata()[:,:,margin-1:]
-            nib.save(nib.Nifti1Image(combined_img, img_in_rsp.affine), tmp_dir / "s01.nii.gz")
+            reassembled = reassemble_image(tmp_dir, img_in_rsp.shape, img_in_rsp.affine, third, margin)
+            nib.save(reassembled, tmp_dir / "s01.nii.gz")
 
         img_pred = nib.load(tmp_dir / "s01.nii.gz")
 

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -528,6 +528,8 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
             affine_s03 = np.copy(base_affine)
             affine_s03[:3, 3] = base_affine[:3, 3] + s03_start * base_affine[:3, 2]
 
+            part_affines = {"s01": base_affine, "s02": affine_s02, "s03": affine_s03}
+
             nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, :third+margin], base_affine),
                     tmp_dir / "s01_0000.nii.gz")
             nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, s02_start:third*2+margin], affine_s02),
@@ -592,7 +594,8 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
                             seg_combined[img_part][seg == jdx] = class_map_inv[class_name]
                 # iterate over subparts of image
                 for img_part in img_parts:
-                    nib.save(nib.Nifti1Image(seg_combined[img_part], img_in_rsp.affine), tmp_dir / f"{img_part}.nii.gz")
+                    part_aff = part_affines[img_part] if do_triple_split else img_in_rsp.affine
+                    nib.save(nib.Nifti1Image(seg_combined[img_part], part_aff), tmp_dir / f"{img_part}.nii.gz")
             elif test == 1:
                 print("WARNING: Using reference seg instead of prediction for testing.")
                 shutil.copy(Path("tests") / "reference_files" / "example_seg.nii.gz", tmp_dir / "s01.nii.gz")

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -517,11 +517,22 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
             third = img_in_rsp.shape[2] // 3
             margin = 20  # set margin with fixed values to avoid rounding problem if using percentage of third
             img_in_rsp_data = img_in_rsp.get_fdata()
-            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, :third+margin], img_in_rsp.affine),
+            base_affine = img_in_rsp.affine
+
+            s02_start = third + 1 - margin
+            s03_start = third * 2 + 1 - margin
+
+            affine_s02 = np.copy(base_affine)
+            affine_s02[:3, 3] = base_affine[:3, 3] + s02_start * base_affine[:3, 2]
+
+            affine_s03 = np.copy(base_affine)
+            affine_s03[:3, 3] = base_affine[:3, 3] + s03_start * base_affine[:3, 2]
+
+            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, :third+margin], base_affine),
                     tmp_dir / "s01_0000.nii.gz")
-            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, third+1-margin:third*2+margin], img_in_rsp.affine),
+            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, s02_start:third*2+margin], affine_s02),
                     tmp_dir / "s02_0000.nii.gz")
-            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, third*2+1-margin:], img_in_rsp.affine),
+            nib.save(nib.Nifti1Image(img_in_rsp_data[:, :, s03_start:], affine_s03),
                     tmp_dir / "s03_0000.nii.gz")
 
         if task_name == "total" and resample is not None and resample[0] < 3.0:


### PR DESCRIPTION
## Summary

- When a large image is split into three sub-volumes along the z-axis for inference, all three parts were saved with the original image's affine. Parts s02 and s03 start at deeper z-offsets, so their spatial origin was incorrect.
- The multimodel merge path also overwrote the corrected affines when saving per-part predictions, so the fix needed to be applied end-to-end.
- Fix: shift the affine origin for s02/s03 by `start_index * affine[:3, 2]` (the z-column vector), and carry the corrected affines through the merge step.
- Extracted `split_image_into_parts()`, `save_merged_predictions()`, and `reassemble_image()` as standalone functions so the split/merge logic is testable without nnU-Net or GPU.
- Added a reusable `tests/mock_imports.py` context manager for importing modules with heavy dependencies mocked, with full sys.modules cleanup.
- 18 tests: 12 for the split/merge/reassembly logic (including the specific regression path), 6 for the mock_imports helper.

## Test plan

- [x] `test_split_affine.py` — verifies affine origins for all parts, voxel-to-world consistency, rotated affines, merged prediction affines (the regression path), roundtrip data integrity, and sys.modules cleanup
- [x] `test_mock_imports.py` — verifies mock injection, removal, transitive cleanup, and pre-existing module preservation
- [ ] Run inference with `force_split=True` on a test image and verify predictions are consistent with non-split inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)