### PR TITLE
Fix AttributeError in save_mask_as_dicomseg on DICOMs with empty SliceThickness

### DIFF
--- a/totalsegmentator/dicom_io.py
+++ b/totalsegmentator/dicom_io.py
@@ -185,7 +185,8 @@ def _extract_orientation_from_datasets(datasets):
             "image_orientation_patient": iop if len(iop) == 6 else None,
             "image_position_patient_first": ipp_list[0] if ipp_list else None,
             "pixel_spacing": pixel_spacing,
-            "slice_thickness": float(getattr(first, 'SliceThickness', 0)) or None,
+            "slice_thickness": (lambda v: float(v) if v not in (None, "") else None)(
+                getattr(first, 'SliceThickness', None)),
             "slice_spacing": slice_spacing,
             "plane": plane
         }
@@ -354,6 +355,11 @@ def save_mask_as_dicomseg(img_data, selected_classes, dcm_reference_file, output
 
     # Derive orientation metadata directly from loaded datasets
     orientation_metadata = _extract_orientation_from_datasets(source_images)
+
+    # Defence: the helper above has a broad `except` that returns None on
+    # any failure. Downstream code dereferences this with .get(), so guard.
+    if orientation_metadata is None:
+        orientation_metadata = {}
 
     # Ensure required DICOM attributes exist (some anonymized files strip these)
     required_str_attrs = {


### PR DESCRIPTION
## Bug

When generating a DICOM SEG from a CT series whose `SliceThickness` tag is present but empty, especially common after anonymisation, e.g. TCIA's Pancreas-CT, `_extract_orientation_from_datasets` crashes inside its broad `except` and returns `None`. `save_mask_as_dicomseg` then dereferences this with `.get(...)`.

## Repro

Any TCIA Pancreas-CT series with `output_type="dicom_seg"`, e.g. SeriesInstanceUID `1.2.826.0.1.3680043.2.1125.1.77419915248783746629465382576486048`. Segmentation finishes; SEG write crashes:

```
File "totalsegmentator/dicom_io.py", line 404, in save_mask_as_dicomseg
    if seg_shape == (dcm_cols, dcm_rows, dcm_slices) and orientation_metadata.get("plane") == "axial":
AttributeError: 'NoneType' object has no attribute 'get'
```

## Root cause

In `_extract_orientation_from_datasets`:

```python
"slice_thickness": float(getattr(first, 'SliceThickness', 0)) or None,
```

`getattr` returns `None` (not the default `0`) when the attribute exists but its value is empty. `float(None)` raises `TypeError`, which the broad `except Exception:` catches and turns into `return None` for the whole helper. The caller in `save_mask_as_dicomseg` then crashes on `.get()`.

## Fix

Two layers:

- Handle present-but-empty `SliceThickness` in the helper.
- Defend `save_mask_as_dicomseg` against `orientation_metadata is None` so future regressions in the helper don't manifest as a crash here.

No behaviour change on well-formed DICOMs.