### PR TITLE
Batch inference: process a folder of images with the model loaded once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# Using TotalSegmentator from automation and AI coding agents
+
+This file is for scripts, pipelines and AI coding agents (e.g. Codex, Claude Code) that drive
+TotalSegmentator non-interactively. It documents how to discover the tool's capabilities,
+invoke it reproducibly and parse its results without scraping human-readable stdout.
+
+For the full feature documentation see [README.md](README.md).
+
+## TL;DR
+
+```bash
+# 1. Discover what the tool can do (instant, no GPU, no model download):
+totalseg_info --json                       # full capability registry as JSON
+
+# 2. Run a segmentation and capture a machine-readable run report:
+TotalSegmentator -i ct.nii.gz -o seg/ --report seg/run_report.json
+
+# 3. Read seg/run_report.json to learn versions, device, classes and output files.
+```
+
+## Discovering capabilities
+
+Do not hard-code task names or class names from the source. Query them instead — the data is
+generated from the same registry the CLI validates against, so it never drifts.
+
+- `totalseg_info --list-tasks` — table of every task (modality CT/MR, whether a license is
+  required, number of classes).
+- `totalseg_info --classes -ta <task>` — the `index -> class_name` map a task outputs. The
+  class names are exactly what `--roi_subset` expects.
+- `totalseg_info --json` — full registry as JSON: `{ "totalsegmentator_version", "tasks": {
+  <task>: { "modality", "license_required", "classes": { "<index>": "<name>" } } } }`.
+- Add `--json` to `--list-tasks` or `--classes` to scope the JSON to just that view.
+
+`totalseg_info` imports no heavy dependencies, needs no GPU and downloads no weights, so it is
+safe to call at planning time to decide which task/classes to request.
+
+The same lists are available on the main command (`TotalSegmentator --list-tasks`,
+`TotalSegmentator --list-classes [task]`), but those load the full runtime; prefer
+`totalseg_info` for quick discovery.
+
+## Running a segmentation
+
+```bash
+TotalSegmentator -i <input> -o <output> -ta <task> [options]
+```
+
+- `-i` accepts a NIfTI file (`.nii` / `.nii.gz`), a folder of DICOM slices, or a zip of DICOM
+  slices. `-o` is a directory of per-class masks, or a single file when `--ml` (multilabel),
+  `dicom_seg` or `dicom_rtstruct` output is used.
+- `-d cpu|gpu|gpu:N|mps` selects the device. Without a GPU the run falls back to CPU (slow);
+  `--fast` (3mm) or `--roi_subset <classes>` reduce runtime and memory.
+- Some tasks require a license (see `license_required` in the registry). Set it once with
+  `totalseg_set_license -l <key>`; free non-commercial licenses:
+  https://backend.totalsegmentator.com/license-academic/
+
+## Reading the run report
+
+Pass `--report <path.json>` to write a manifest after the run completes. It contains:
+
+| field | meaning |
+|-------|---------|
+| `totalsegmentator_version`, `nnunetv2_version`, `torch_version` | software versions used |
+| `task`, `modality`, `license_required` | what was run |
+| `device` | resolved device (`gpu` / `cpu` / `mps`) |
+| `fast`, `fastest`, `multilabel`, `output_type`, `roi_subset` | run options |
+| `input`, `output` | resolved paths (or `"Nifti1Image"` for an in-memory input) |
+| `num_classes`, `classes` | classes produced (`index -> name`), filtered by `roi_subset` |
+| `runtime_seconds` | wall-clock segmentation time |
+| `output_files` | `*.nii.gz` files written to the output directory |
+
+This lets a pipeline verify a run and chain the next step (e.g. feed `output_files` into
+`totalseg_combine_masks` or statistics) without parsing stdout.
+
+For per-class volume and intensity, add `--statistics` (writes `statistics.json`).
+
+## Exit codes
+
+- `0` — success.
+- `1` — runtime error (e.g. a licensed task without a valid license; any unhandled exception).
+- `2` — argument error (unknown task, missing `-i`/`-o` for a segmentation run, etc.).
+
+Add `--quiet` to suppress progress text and `--debug` to print the input path and task on
+error. Stdout is intended for humans; rely on `--report` and `--statistics` JSON for parsing.
+
+## Python API
+
+```python
+from totalsegmentator.python_api import totalsegmentator
+seg_img = totalsegmentator("ct.nii.gz", "seg/", task="total")
+```
+
+The task registry is importable directly (no torch required):
+
+```python
+from totalsegmentator.registry import list_tasks, get_task_classes, task_registry
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,14 +75,24 @@ For per-class volume and intensity, add `--statistics` (writes `statistics.json`
 Add `--statistics_extra` for `n_voxels`, intensity std/min/max and the morphometric
 `centroid_vox` / `bbox_vox` (voxel coordinates).
 
-## Cohort analysis
+## Cohort processing
 
-When processing many images, merge their per-image `statistics.json` into one
-analysis-ready table (format chosen by the `-o` extension: `.csv`, `.parquet`, `.json`):
+To segment a whole folder of images, use `totalseg_batch`. It loads the model once and
+reuses it across all images (much faster than calling `TotalSegmentator` per file), keeps
+going if one image fails (failures go to `batch_errors.log`), and exits non-zero if any
+image failed:
+
+```bash
+totalseg_batch -i ct_folder -o out_folder --statistics   # each case -> out_folder/<case_id>/
+```
+
+To merge the per-image `statistics.json` of a cohort into one analysis-ready table (format
+chosen by the `-o` extension: `.csv`, `.parquet`, `.json`):
 
 ```bash
 totalseg_aggregate_stats -i cohort_dir -o cohort_stats.csv
 ```
+(With `--statistics`, `totalseg_batch` writes this table as `out_folder/cohort_statistics.csv` automatically.)
 
 Output is tidy/long — one row per `(subject, structure)`, one column per metric (nested
 metrics like `centroid_vox` are flattened to `centroid_vox_0/1/2`). Subject ids come from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,21 @@ This lets a pipeline verify a run and chain the next step (e.g. feed `output_fil
 `totalseg_combine_masks` or statistics) without parsing stdout.
 
 For per-class volume and intensity, add `--statistics` (writes `statistics.json`).
+Add `--statistics_extra` for `n_voxels`, intensity std/min/max and the morphometric
+`centroid_vox` / `bbox_vox` (voxel coordinates).
+
+## Cohort analysis
+
+When processing many images, merge their per-image `statistics.json` into one
+analysis-ready table (format chosen by the `-o` extension: `.csv`, `.parquet`, `.json`):
+
+```bash
+totalseg_aggregate_stats -i cohort_dir -o cohort_stats.csv
+```
+
+Output is tidy/long — one row per `(subject, structure)`, one column per metric (nested
+metrics like `centroid_vox` are flattened to `centroid_vox_0/1/2`). Subject ids come from
+each file's path relative to `cohort_dir`. This needs no GPU or model.
 
 ## Exit codes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Master
+* add `totalseg_batch` command to process a folder of images in one run, loading the model weights only once and reusing them across all images (much faster than a shell loop on a cohort). Per-image failures are logged and the run continues; with `--statistics` the per-case statistics are aggregated into one table.
 * add `totalseg_aggregate_stats` command to merge the per-image `statistics.json` files of a whole cohort into one analysis-ready table (CSV, parquet or JSON). Makes downstream analysis in pandas/R straightforward.
 * add `--statistics_extra` option to compute additional per-structure metrics (`n_voxels`, intensity std/min/max, and the morphometric `centroid_vox` and `bbox_vox`). Off by default so the normal statistics runtime is unchanged.
 * add `totalseg_info` command to discover available tasks and their output classes (modality, license, class index -> name) as a human-readable table or JSON. Runs instantly without a GPU or model download. Useful for scripting and AI coding agents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Master
+* add `totalseg_info` command to discover available tasks and their output classes (modality, license, class index -> name) as a human-readable table or JSON. Runs instantly without a GPU or model download. Useful for scripting and AI coding agents.
+* add `--list-tasks` and `--list-classes [task]` flags to the main `TotalSegmentator` command for the same discovery directly on the CLI.
+* add `--report <path.json>` option to write a machine-readable run manifest (software/model versions, device, task, classes, runtime, output files) for reproducible pipelines.
+* add `AGENTS.md` with guidance for using TotalSegmentator from automation and AI coding agents.
 * allow to pass minimum component size in mm3 to `--remove_small_blobs` argument (before was hard coded to 200mm3)
 * add improved model for `totalseg_get_body_stats` script: use CNN model instead of XGBoost model.
 * if `-l` is passed the backend license server will only be contacted if the license number is not already set in the config file or if you pass a different license number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Master
+* add `totalseg_aggregate_stats` command to merge the per-image `statistics.json` files of a whole cohort into one analysis-ready table (CSV, parquet or JSON). Makes downstream analysis in pandas/R straightforward.
+* add `--statistics_extra` option to compute additional per-structure metrics (`n_voxels`, intensity std/min/max, and the morphometric `centroid_vox` and `bbox_vox`). Off by default so the normal statistics runtime is unchanged.
 * add `totalseg_info` command to discover available tasks and their output classes (modality, license, class index -> name) as a human-readable table or JSON. Runs instantly without a GPU or model download. Useful for scripting and AI coding agents.
 * add `--list-tasks` and `--list-classes [task]` flags to the main `TotalSegmentator` command for the same discovery directly on the CLI.
 * add `--report <path.json>` option to write a machine-readable run manifest (software/model versions, device, task, classes, runtime, output files) for reproducible pipelines.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Thank you to [INGEDATA](https://www.ingedata.ai/) for providing a team of radiol
 * `--preview`: This will generate a 3D rendering of all classes, giving you a quick overview if the segmentation worked and where it failed (see `preview.png` in output directory).
 * `--ml`: This will save one nifti file containing all labels instead of one file for each class. Saves runtime during saving of nifti files. (see [here](https://github.com/wasserth/TotalSegmentator#class-details) for index to class name mapping).
 * `--statistics`: This will generate a file `statistics.json` with volume (in mm³) and mean intensity of each class.
+* `--statistics_extra`: In addition to volume and intensity, also compute `n_voxels`, intensity std/min/max and the morphometric `centroid_vox` and `bbox_vox` (voxel coordinates) for each class. Off by default to keep the statistics runtime unchanged.
 * `--radiomics`: This will generate a file `statistics_radiomics.json` with the radiomics features of each class. You have to install pyradiomics to use this (`pip install pyradiomics`).
 * `--output_type`: This will output the segmentation as DICOM. Supported are `dicom_seg` requires (`pip install highdicom`) and `dicom_rtstruct` requires (`pip install rt_utils`).
 * `--report`: This will write a machine-readable JSON run manifest to the given path (software and model versions, resolved device, task, classes, runtime and the list of output files). Useful for reproducible pipelines and automation.
@@ -142,6 +143,12 @@ totalseg_info --list-tasks              # table of tasks (modality, license, num
 totalseg_info --classes -ta total       # class index -> name for one task
 totalseg_info --json                    # full capability registry as JSON
 ```
+
+If you ran TotalSegmentator with `--statistics` on a cohort of images, you can merge all the per-image `statistics.json` files into one analysis-ready table (one row per subject and structure). The output format is chosen by the extension of `-o` (`.csv`, `.parquet` or `.json`):
+```bash
+totalseg_aggregate_stats -i cohort_dir -o cohort_stats.csv
+```
+Subject ids are taken from the path of each statistics file relative to the input directory (e.g. `cohort_dir/subj001/statistics.json` -> `subj001`). Use `--filename statistics_radiomics.json` to aggregate radiomics features instead.
 
 If you want to know body weight, size, age, sex, BMI and BSA you can use the following command (requires `pip install timm monai`). It runs on CPU in <1min. It requires a license which you can get for free for non-commercial usage [here](https://backend.totalsegmentator.com/license-academic/). More details can be found [here](resources/body_stats_prediction.md):
 ```bash

--- a/README.md
+++ b/README.md
@@ -130,9 +130,18 @@ Thank you to [INGEDATA](https://www.ingedata.ai/) for providing a team of radiol
 * `--statistics`: This will generate a file `statistics.json` with volume (in mm³) and mean intensity of each class.
 * `--radiomics`: This will generate a file `statistics_radiomics.json` with the radiomics features of each class. You have to install pyradiomics to use this (`pip install pyradiomics`).
 * `--output_type`: This will output the segmentation as DICOM. Supported are `dicom_seg` requires (`pip install highdicom`) and `dicom_rtstruct` requires (`pip install rt_utils`).
+* `--report`: This will write a machine-readable JSON run manifest to the given path (software and model versions, resolved device, task, classes, runtime and the list of output files). Useful for reproducible pipelines and automation.
+* `--list-tasks` / `--list-classes [task]`: Print the available tasks (or the classes of one task) and exit, without running a segmentation. For machine-readable output use the `totalseg_info` command below.
 
 
 ### Other commands
+
+If you want to discover which tasks are available and which classes each one outputs (e.g. to find valid `--roi_subset` names) you can use the `totalseg_info` command. It runs instantly, needs no GPU and downloads no model weights, which also makes it convenient for scripts and AI coding agents:
+```bash
+totalseg_info --list-tasks              # table of tasks (modality, license, number of classes)
+totalseg_info --classes -ta total       # class index -> name for one task
+totalseg_info --json                    # full capability registry as JSON
+```
 
 If you want to know body weight, size, age, sex, BMI and BSA you can use the following command (requires `pip install timm monai`). It runs on CPU in <1min. It requires a license which you can get for free for non-commercial usage [here](https://backend.totalsegmentator.com/license-academic/). More details can be found [here](resources/body_stats_prediction.md):
 ```bash

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ totalseg_info --classes -ta total       # class index -> name for one task
 totalseg_info --json                    # full capability registry as JSON
 ```
 
+If you want to process a whole folder of images (a cohort) you can use the following command. It loads the model weights only once and reuses them for every image, which is much faster than calling `TotalSegmentator` in a shell loop. Each case is written to `<output>/<case_id>/`, per-image failures are logged to `batch_errors.log` and the run continues, and with `--statistics` the per-case statistics are aggregated into `cohort_statistics.csv`:
+```bash
+totalseg_batch -i ct_folder -o output_folder --statistics
+```
+
 If you ran TotalSegmentator with `--statistics` on a cohort of images, you can merge all the per-image `statistics.json` files into one analysis-ready table (one row per subject and structure). The output format is chosen by the extension of `-o` (`.csv`, `.parquet` or `.json`):
 ```bash
 totalseg_aggregate_stats -i cohort_dir -o cohort_stats.csv

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(name='TotalSegmentator',
                 'totalseg_evans_index=totalsegmentator.bin.totalseg_evans_index:main',
                 'totalseg_get_body_stats=totalsegmentator.bin.totalseg_get_body_stats:main',
                 'totalseg_info=totalsegmentator.bin.totalseg_info:main',
-                'totalseg_aggregate_stats=totalsegmentator.bin.totalseg_aggregate_stats:main'
+                'totalseg_aggregate_stats=totalsegmentator.bin.totalseg_aggregate_stats:main',
+                'totalseg_batch=totalsegmentator.bin.totalseg_batch:main'
             ],
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(name='TotalSegmentator',
                 'totalseg_get_phase=totalsegmentator.bin.totalseg_get_phase:main',
                 'totalseg_get_modality=totalsegmentator.bin.totalseg_get_modality:main',
                 'totalseg_evans_index=totalsegmentator.bin.totalseg_evans_index:main',
-                'totalseg_get_body_stats=totalsegmentator.bin.totalseg_get_body_stats:main'
+                'totalseg_get_body_stats=totalsegmentator.bin.totalseg_get_body_stats:main',
+                'totalseg_info=totalsegmentator.bin.totalseg_info:main'
             ],
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(name='TotalSegmentator',
                 'totalseg_get_modality=totalsegmentator.bin.totalseg_get_modality:main',
                 'totalseg_evans_index=totalsegmentator.bin.totalseg_evans_index:main',
                 'totalseg_get_body_stats=totalsegmentator.bin.totalseg_get_body_stats:main',
-                'totalseg_info=totalsegmentator.bin.totalseg_info:main'
+                'totalseg_info=totalsegmentator.bin.totalseg_info:main',
+                'totalseg_aggregate_stats=totalsegmentator.bin.totalseg_aggregate_stats:main'
             ],
         },
     )

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,43 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from totalsegmentator.bin.totalseg_batch import find_images, case_id, output_target
+
+
+class TestBatchHelpers(unittest.TestCase):
+
+    def test_case_id(self):
+        self.assertEqual(case_id(Path("/x/ct.nii.gz")), "ct")
+        self.assertEqual(case_id(Path("/x/subj01.nii")), "subj01")
+        self.assertEqual(case_id(Path("/x/a.b.nii.gz")), "a.b")
+
+    def test_output_target(self):
+        out = Path("/out")
+        self.assertEqual(output_target(out, "c1", ml=False), Path("/out/c1"))
+        self.assertEqual(output_target(out, "c1", ml=True), Path("/out/c1/segmentation.nii.gz"))
+
+    def test_find_images_default(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "a.nii.gz").write_text("x")
+            (d / "b.nii").write_text("x")
+            (d / "notes.txt").write_text("x")
+            (d / "sub").mkdir()
+            (d / "sub" / "deep.nii.gz").write_text("x")  # not picked up by default (not direct)
+            names = [p.name for p in find_images(d)]
+            self.assertEqual(names, ["a.nii.gz", "b.nii"])
+
+    def test_find_images_pattern(self):
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "s1").mkdir()
+            (d / "s2").mkdir()
+            (d / "s1" / "ct.nii.gz").write_text("x")
+            (d / "s2" / "ct.nii.gz").write_text("x")
+            rel = sorted(str(p.relative_to(d)) for p in find_images(d, pattern="*/ct.nii.gz"))
+            self.assertEqual(rel, ["s1/ct.nii.gz", "s2/ct.nii.gz"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,138 @@
+import sys
+import json
+import subprocess
+import unittest
+
+import pytest
+
+from totalsegmentator.registry import (
+    TASKS, task_modality, requires_license, get_task_classes,
+    list_tasks, task_registry, format_tasks_table, format_classes_table,
+)
+from totalsegmentator.map_to_binary import commercial_models
+
+
+class TestRegistry(unittest.TestCase):
+    """Pure-data tests for the task registry. No torch / GPU / model weights needed."""
+
+    def test_tasks_unique(self):
+        self.assertEqual(len(TASKS), len(set(TASKS)), "TASKS contains duplicates")
+
+    def test_every_task_has_classes(self):
+        for t in TASKS:
+            classes = get_task_classes(t)
+            self.assertIsInstance(classes, dict)
+            self.assertGreater(len(classes), 0, f"task '{t}' has no classes")
+
+    def test_known_examples(self):
+        self.assertEqual(task_modality("total"), "CT")
+        self.assertFalse(requires_license("total"))
+        self.assertEqual(len(get_task_classes("total")), 117)
+        self.assertEqual(task_modality("total_mr"), "MR")
+        self.assertEqual(task_modality("body_mr"), "MR")
+        # TOF-MRI task whose name does not end in "_mr"
+        self.assertEqual(task_modality("brain_aneurysm"), "MR")
+        self.assertTrue(requires_license("tissue_types"))
+
+    def test_license_flag_matches_commercial_models(self):
+        # Every licensed task is listed, and every commercial model is a selectable task.
+        self.assertTrue(set(commercial_models).issubset(set(TASKS)))
+        for t in TASKS:
+            self.assertEqual(requires_license(t), t in commercial_models)
+
+    def test_legacy_task_has_own_classes(self):
+        # LEGACY variants are real tasks with their own (older) class map.
+        legacy = get_task_classes("lung_vessels_LEGACY")
+        self.assertGreater(len(legacy), 0)
+        self.assertNotEqual(legacy, get_task_classes("lung_vessels"))
+
+    def test_unknown_task_raises(self):
+        with self.assertRaises(KeyError):
+            get_task_classes("does_not_exist")
+
+    def test_list_tasks_shape(self):
+        rows = list_tasks()
+        self.assertEqual(len(rows), len(TASKS))
+        for r in rows:
+            self.assertEqual(set(r), {"name", "modality", "license_required", "num_classes"})
+            self.assertIn(r["modality"], {"CT", "MR"})
+
+    def test_task_registry_json_roundtrip(self):
+        reg = task_registry()
+        dumped = json.dumps(reg)  # must be JSON-serializable
+        reloaded = json.loads(dumped)
+        self.assertEqual(set(reloaded["tasks"]), set(TASKS))
+        total = reloaded["tasks"]["total"]
+        self.assertEqual(total["modality"], "CT")
+        self.assertEqual(total["classes"]["1"], "spleen")
+
+    def test_format_helpers_run(self):
+        self.assertIn("total", format_tasks_table())
+        self.assertIn("spleen", format_classes_table("total"))
+
+
+class TestTotalsegInfoCLI(unittest.TestCase):
+    """Smoke tests for the totalseg_info command (no heavy dependencies)."""
+
+    def _run(self, *args):
+        return subprocess.run([sys.executable, "-m", "totalsegmentator.bin.totalseg_info", *args],
+                              capture_output=True, text=True)
+
+    def test_list_tasks(self):
+        r = self._run("--list-tasks")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("total", r.stdout)
+
+    def test_json_registry(self):
+        r = self._run("--json")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        data = json.loads(r.stdout)
+        self.assertEqual(len(data["tasks"]), len(TASKS))
+
+    def test_classes_for_task(self):
+        r = self._run("--classes", "-ta", "total", "--json")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        data = json.loads(r.stdout)
+        self.assertEqual(data["1"], "spleen")
+
+    def test_classes_without_task_errors(self):
+        r = self._run("--classes")
+        self.assertEqual(r.returncode, 2)
+
+
+class TestRunReport(unittest.TestCase):
+    """Tests for the run-report builder. Needs torch + nibabel (present in CI)."""
+
+    def test_build_run_report(self):
+        pytest.importorskip("torch")
+        pytest.importorskip("nibabel")
+        from totalsegmentator.python_api import build_run_report
+
+        report = build_run_report(
+            input="ct.nii.gz", output=None, task="total", device="cpu",
+            fast=False, fastest=False, ml=False, output_type="nifti",
+            roi_subset=["liver", "spleen"], runtime_seconds=12.345)
+
+        expected_keys = {
+            "totalsegmentator_version", "nnunetv2_version", "torch_version",
+            "task", "modality", "license_required", "device", "fast", "fastest",
+            "multilabel", "output_type", "roi_subset", "input", "output",
+            "num_classes", "classes", "runtime_seconds", "output_files",
+        }
+        self.assertEqual(set(report), expected_keys)
+        self.assertEqual(report["task"], "total")
+        self.assertEqual(report["modality"], "CT")
+        self.assertFalse(report["license_required"])
+        self.assertEqual(report["device"], "cpu")
+        self.assertEqual(report["input"], "ct.nii.gz")
+        self.assertIsNone(report["output"])
+        self.assertEqual(report["runtime_seconds"], 12.35)
+        # roi_subset filters the class list down to the requested names.
+        self.assertEqual(report["num_classes"], 2)
+        self.assertEqual(set(report["classes"].values()), {"liver", "spleen"})
+        # report is JSON-serializable
+        json.dumps(report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_utils.py
+++ b/tests/test_research_utils.py
@@ -1,0 +1,128 @@
+import sys
+import csv
+import json
+import tempfile
+import subprocess
+import unittest
+from pathlib import Path
+
+import pytest
+
+from totalsegmentator.bin.totalseg_aggregate_stats import (
+    flatten, rows_from_stats, collect_rows, ordered_columns, write_table,
+)
+
+
+class TestFlatten(unittest.TestCase):
+    def test_scalar(self):
+        self.assertEqual(flatten("volume", 12.0), {"volume": 12.0})
+
+    def test_list(self):
+        self.assertEqual(flatten("centroid_vox", [1.0, 2.0, 3.0]),
+                         {"centroid_vox_0": 1.0, "centroid_vox_1": 2.0, "centroid_vox_2": 3.0})
+
+    def test_nested_list(self):
+        self.assertEqual(flatten("bbox_vox", [[4, 6], [4, 6]]),
+                         {"bbox_vox_0_0": 4, "bbox_vox_0_1": 6, "bbox_vox_1_0": 4, "bbox_vox_1_1": 6})
+
+
+class TestAggregate(unittest.TestCase):
+    def _cohort(self, tmp):
+        (tmp / "s1").mkdir()
+        (tmp / "site2" / "s3").mkdir(parents=True)
+        (tmp / "s1" / "statistics.json").write_text(json.dumps(
+            {"spleen": {"volume": 27.0, "intensity": 20.0, "centroid_vox": [5.0, 5.0, 5.0]},
+             "liver": {"volume": 0.0, "intensity": 0.0}}))
+        (tmp / "site2" / "s3" / "statistics.json").write_text(json.dumps(
+            {"spleen": {"volume": 19.0, "intensity": 18.0}}))
+
+    def test_rows_from_stats(self):
+        rows = rows_from_stats({"spleen": {"volume": 1.0, "centroid_vox": [1, 2, 3]}}, "subjA")
+        self.assertEqual(rows, [{"subject": "subjA", "structure": "spleen",
+                                 "volume": 1.0, "centroid_vox_0": 1, "centroid_vox_1": 2, "centroid_vox_2": 3}])
+
+    def test_collect_and_columns(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._cohort(tmp)
+            rows, n = collect_rows(tmp, "statistics.json", quiet=True)
+            self.assertEqual(n, 2)
+            self.assertEqual(len(rows), 3)  # 2 structures + 1 structure
+            self.assertEqual({r["subject"] for r in rows}, {"s1", "site2/s3"})
+            cols = ordered_columns(rows)
+            self.assertEqual(cols[:4], ["subject", "structure", "volume", "intensity"])
+            self.assertIn("centroid_vox_2", cols)
+
+    def test_cli_csv(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._cohort(tmp)
+            out = tmp / "agg.csv"
+            r = subprocess.run([sys.executable, "-m", "totalsegmentator.bin.totalseg_aggregate_stats",
+                                "-i", str(tmp), "-o", str(out), "-q"], capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, r.stderr)
+            with open(out) as f:
+                reader = list(csv.DictReader(f))
+            self.assertEqual(len(reader), 3)
+            spleen_s1 = [row for row in reader if row["subject"] == "s1" and row["structure"] == "spleen"][0]
+            self.assertEqual(spleen_s1["volume"], "27.0")
+            self.assertEqual(spleen_s1["centroid_vox_0"], "5.0")
+
+    def test_cli_empty_cohort_exits_2(self):
+        with tempfile.TemporaryDirectory() as d:
+            r = subprocess.run([sys.executable, "-m", "totalsegmentator.bin.totalseg_aggregate_stats",
+                                "-i", d, "-o", str(Path(d) / "x.csv")], capture_output=True, text=True)
+            self.assertEqual(r.returncode, 2)
+
+    def test_parquet_roundtrip(self):
+        pytest.importorskip("pyarrow")
+        import pyarrow.parquet as pq
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._cohort(tmp)
+            out = tmp / "agg.parquet"
+            rows, _ = collect_rows(tmp, "statistics.json", quiet=True)
+            write_table(rows, ordered_columns(rows), out)
+            table = pq.read_table(out)
+            self.assertEqual(table.num_rows, 3)
+            self.assertIn("volume", table.column_names)
+
+
+class TestExtraMetrics(unittest.TestCase):
+    """Needs numpy + nibabel (present in CI)."""
+
+    def test_extra_metrics(self):
+        np = pytest.importorskip("numpy")
+        nib = pytest.importorskip("nibabel")
+        from totalsegmentator.statistics import get_basic_statistics
+
+        seg = np.zeros((10, 10, 10), dtype=np.uint8)
+        seg[4:7, 4:7, 4:7] = 1  # spleen, interior (not touching border)
+        ct = np.full((10, 10, 10), -50.0)
+        ct[seg == 1] = 25.0
+        img = nib.Nifti1Image(ct, np.eye(4))
+
+        stats = get_basic_statistics(seg, img, None, quiet=True, task="total",
+                                     roi_subset=["spleen"], extra_metrics=True)
+        sp = stats["spleen"]
+        self.assertEqual(sp["n_voxels"], 27)
+        self.assertEqual(sp["bbox_vox"], [[4, 6], [4, 6], [4, 6]])
+        self.assertEqual(sp["centroid_vox"], [5.0, 5.0, 5.0])
+        self.assertEqual(sp["intensity_min"], 25.0)
+        self.assertEqual(sp["intensity_max"], 25.0)
+
+    def test_default_has_no_extra_metrics(self):
+        np = pytest.importorskip("numpy")
+        nib = pytest.importorskip("nibabel")
+        from totalsegmentator.statistics import get_basic_statistics
+
+        seg = np.zeros((10, 10, 10), dtype=np.uint8)
+        seg[4:7, 4:7, 4:7] = 1
+        ct = np.zeros((10, 10, 10))
+        img = nib.Nifti1Image(ct, np.eye(4))
+        stats = get_basic_statistics(seg, img, None, quiet=True, task="total", roi_subset=["spleen"])
+        self.assertEqual(set(stats["spleen"]), {"volume", "intensity"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -43,6 +43,12 @@ pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_fast
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_statistics
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_preview
 
+# Research utilities: cohort statistics aggregation + extra metrics (no GPU needed)
+pytest -v tests/test_research_utils.py
+# Aggregate the statistics.json just produced into a cohort table
+totalseg_aggregate_stats -i tests/unittest_prediction_fast -o tests/unittest_cohort_stats.csv
+python -c "import csv; rows=list(csv.DictReader(open('tests/unittest_cohort_stats.csv'))); assert len(rows)>0, 'empty cohort table'"
+
 # Test - fast - multilabel
 TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction_fast.nii.gz --fast --ml -d cpu
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel_fast
@@ -73,4 +79,5 @@ rm tests/unittest_prediction_fast_body_seg.nii.gz
 rm tests/unittest_phase_prediction.json
 rm tests/unittest_body_stats_prediction.json
 rm tests/unittest_run_report.json
+rm tests/unittest_cohort_stats.csv
 # rm tests/statistics.json

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -12,6 +12,9 @@ pytest -v tests/test_config.py
 # Test task registry + totalseg_info command (no GPU/model needed)
 pytest -v tests/test_registry.py
 
+# Test batch command helpers (no GPU/model needed)
+pytest -v tests/test_batch.py
+
 # Smoke test the introspection commands
 totalseg_info --list-tasks > /dev/null
 totalseg_info --classes -ta total --json > /dev/null
@@ -21,6 +24,13 @@ TotalSegmentator --list-tasks > /dev/null
 TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu --report tests/unittest_run_report.json
 python -c "import json; r=json.load(open('tests/unittest_run_report.json')); assert r['task']=='total' and r['num_classes']>0, r"
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
+
+# Test - batch processing. Verifies that the cached-predictor (batch) path produces a
+# segmentation identical to the normal single-image path above (same options, same image).
+mkdir -p tests/unittest_batch_in
+cp tests/reference_files/example_ct_sm.nii.gz tests/unittest_batch_in/
+totalseg_batch -i tests/unittest_batch_in -o tests/unittest_batch_out -bs --ml -d cpu
+python -c "import nibabel as nib, numpy as np; a=nib.load('tests/unittest_prediction.nii.gz').get_fdata(); b=nib.load('tests/unittest_batch_out/example_ct_sm/segmentation.nii.gz').get_fdata(); assert np.array_equal(a, b), 'batch output differs from single-image output'"
 
 # Test - roi subset
 # 2 cpus:
@@ -79,4 +89,6 @@ rm tests/unittest_phase_prediction.json
 rm tests/unittest_body_stats_prediction.json
 rm tests/unittest_run_report.json
 rm tests/unittest_cohort_stats.csv
+rm -rf tests/unittest_batch_in
+rm -rf tests/unittest_batch_out
 # rm tests/statistics.json

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,7 +21,6 @@ TotalSegmentator --list-tasks > /dev/null
 TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu --report tests/unittest_run_report.json
 python -c "import json; r=json.load(open('tests/unittest_run_report.json')); assert r['task']=='total' and r['num_classes']>0, r"
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
-pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 
 # Test - roi subset
 # 2 cpus:

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -9,8 +9,18 @@ pytest -v tests/test_device_type.py
 # Test config helpers
 pytest -v tests/test_config.py
 
-# Test - multilabel prediction
-TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu
+# Test task registry + totalseg_info command (no GPU/model needed)
+pytest -v tests/test_registry.py
+
+# Smoke test the introspection commands
+totalseg_info --list-tasks > /dev/null
+totalseg_info --classes -ta total --json > /dev/null
+TotalSegmentator --list-tasks > /dev/null
+
+# Test - multilabel prediction (also exercises --report manifest)
+TotalSegmentator -i tests/reference_files/example_ct_sm.nii.gz -o tests/unittest_prediction.nii.gz -bs --ml -d cpu --report tests/unittest_run_report.json
+python -c "import json; r=json.load(open('tests/unittest_run_report.json')); assert r['task']=='total' and r['num_classes']>0, r"
+pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 pytest -v tests/test_end_to_end.py::test_end_to_end::test_prediction_multilabel
 
 # Test - roi subset
@@ -62,4 +72,5 @@ rm tests/unittest_prediction_fast_force_split.nii.gz
 rm tests/unittest_prediction_fast_body_seg.nii.gz
 rm tests/unittest_phase_prediction.json
 rm tests/unittest_body_stats_prediction.json
+rm tests/unittest_run_report.json
 # rm tests/statistics.json

--- a/totalsegmentator/bin/TotalSegmentator.py
+++ b/totalsegmentator/bin/TotalSegmentator.py
@@ -133,6 +133,11 @@ def main():
                         help="Aggregation method for intensity statistics (default: mean).",
                         default="mean")
 
+    parser.add_argument("-sx", "--statistics_extra", action="store_true",
+                        help="Add extra per-structure metrics to the statistics: n_voxels, intensity std/min/max, "
+                             "and the morphometric centroid_vox and bbox_vox (voxel coordinates). Slightly increases statistics runtime.",
+                        default=False)
+
     parser.add_argument("-cp", "--crop_path", help="Custom path to masks used for cropping. If not set will use output directory.",
                         type=lambda p: Path(p).absolute(), default=None)
 
@@ -249,7 +254,8 @@ def main():
                      roi_subset_robust=args.roi_subset_robust, stats_aggregation=args.stats_aggregation, 
                      remove_small_blobs=args.remove_small_blobs, statistics_normalized_intensities=False,
                      robust_crop=args.robust_crop, higher_order_resampling=args.higher_order_resampling,
-                     save_probabilities=args.save_probabilities, debug=args.debug, report=args.report)
+                     save_probabilities=args.save_probabilities, debug=args.debug, report=args.report,
+                     statistics_extra=args.statistics_extra)
 
 
 if __name__ == '__main__':

--- a/totalsegmentator/bin/TotalSegmentator.py
+++ b/totalsegmentator/bin/TotalSegmentator.py
@@ -4,6 +4,7 @@ import importlib.metadata
 from pathlib import Path
 import re
 from totalsegmentator.python_api import totalsegmentator, validate_device_type_api
+from totalsegmentator.registry import TASKS, format_tasks_table, format_classes_table
 
 
 def validate_device_type(value):
@@ -49,14 +50,16 @@ def main():
                                      epilog="Written by Jakob Wasserthal. If you use this tool please cite https://pubs.rsna.org/doi/10.1148/ryai.230024")
 
     parser.add_argument("-i", metavar="filepath", dest="input",
-                        help="CT nifti image or folder of dicom slices or zip file of dicom slices.",
-                        type=lambda p: Path(p).absolute(), required=True)
+                        help="CT nifti image or folder of dicom slices or zip file of dicom slices. "
+                             "(Required for segmentation; not needed for --list-tasks / --list-classes.)",
+                        type=lambda p: Path(p).absolute(), required=False)
 
     parser.add_argument("-o", metavar="directory", dest="output",
-                        help="Output directory for segmentation masks. " + 
-                             "Or path of multilabel output nifti file if --ml option is used." + 
-                             "Or path of output dicom seg file if --output_type is set to 'dicom_seg' or 'dicom_rtstruct'",
-                        type=lambda p: Path(p).absolute(), required=True)
+                        help="Output directory for segmentation masks. " +
+                             "Or path of multilabel output nifti file if --ml option is used." +
+                             "Or path of output dicom seg file if --output_type is set to 'dicom_seg' or 'dicom_rtstruct'. " +
+                             "(Required for segmentation; not needed for --list-tasks / --list-classes.)",
+                        type=lambda p: Path(p).absolute(), required=False)
 
     parser.add_argument("-ot", "--output_type", type=str, nargs="+",
                     help="Select output type(s). Choices: nifti, dicom_rtstruct, dicom_seg. Multiple are allowed e.g. -ot nifti dicom_seg OR -ot nifti,dicom_seg).",
@@ -86,18 +89,11 @@ def main():
 
     # cerebral_bleed: Intracerebral hemorrhage
     # liver_vessels: hepatic vessels
-    parser.add_argument("-ta", "--task", choices=["total", "body", "body_mr", "vertebrae_mr",
-                        "lung_vessels", "lung_vessels_LEGACY", "cerebral_bleed", "hip_implant", "coronary_arteries", "coronary_arteries_LEGACY",
-                        "pleural_pericard_effusion", "test",
-                        "appendicular_bones", "appendicular_bones_mr", "tissue_types", "heartchambers_highres",
-                        "face", "vertebrae_body", "total_mr", "tissue_types_mr", "tissue_4_types", "face_mr",
-                        "head_glands_cavities", "head_muscles", "headneck_bones_vessels", "headneck_muscles",
-                        "brain_structures", "liver_vessels", "liver_lesions", "liver_lesions_mr", "oculomotor_muscles",
-                        "thigh_shoulder_muscles", "thigh_shoulder_muscles_mr", "lung_nodules", "kidney_cysts", 
-                        "breasts", "ventricle_parts", "aortic_sinuses", "liver_segments", "liver_segments_mr",
-                        "total_highres_test", "craniofacial_structures", "abdominal_muscles", "teeth",
-                        "trunk_cavities", "brain_aneurysm"],
-                        help="Select which model to use. This determines what is predicted.",
+    # The list of selectable tasks lives in totalsegmentator/registry.py (TASKS) so that the
+    # CLI choices and the totalseg_info introspection command can never drift apart.
+    parser.add_argument("-ta", "--task", choices=TASKS, metavar="task",
+                        help="Select which model to use. This determines what is predicted. "
+                             "Run 'totalseg_info --list-tasks' to see all options.",
                         default="total")
 
     parser.add_argument("-rs", "--roi_subset", type=str, nargs="+",
@@ -123,6 +119,11 @@ def main():
     parser.add_argument("-r", "--radiomics", action="store_true",
                         help="Calc radiomics features. Requires pyradiomics. Results will be in statistics_radiomics.json",
                         default=False)
+
+    parser.add_argument("-rp", "--report", type=lambda p: Path(p).absolute(), default=None,
+                        metavar="filepath",
+                        help="Write a machine-readable JSON run report (software/model versions, device, task, "
+                             "classes, runtime, output files) to this path. Useful for reproducible pipelines and automation.")
 
     parser.add_argument("-sii", "--stats_include_incomplete", action="store_true",
                         help="Normally statistics are only calculated for ROIs which are not cut off by the beginning or end of image. Use this option to calc anyways.",
@@ -190,9 +191,34 @@ def main():
                         help="Only needed for unittesting.",
                         default=0)
 
+    parser.add_argument("-lt", "--list-tasks", action="store_true", dest="list_tasks",
+                        help="List all available tasks (modality, license, number of classes) and exit. "
+                             "For machine-readable output use 'totalseg_info --json'.")
+
+    parser.add_argument("-lc", "--list-classes", dest="list_classes", nargs="?", const="total",
+                        metavar="task",
+                        help="List the classes of a task (index -> name) and exit. Defaults to 'total'.")
+
     parser.add_argument('--version', action='version', version=importlib.metadata.version("TotalSegmentator"))
 
     args = parser.parse_args()
+
+    # Capability discovery: these short-circuit before any input/output is required and
+    # before models are loaded, so scripts/agents can introspect the tool quickly.
+    if args.list_tasks:
+        print(format_tasks_table())
+        return
+    if args.list_classes is not None:
+        if args.list_classes not in TASKS:
+            parser.error(f"unknown task '{args.list_classes}' for --list-classes. "
+                         "Run --list-tasks to see all options.")
+        print(format_classes_table(args.list_classes))
+        return
+
+    # For an actual segmentation run, input and output are required.
+    missing = [flag for flag, val in (("-i", args.input), ("-o", args.output)) if val is None]
+    if missing:
+        parser.error(f"the following arguments are required for segmentation: {', '.join(missing)}")
 
     normalized_output_type = ["nifti"] if args.output_type is None else normalize_output_types(args.output_type)
     # Backward compatibility: single element stays a string
@@ -223,7 +249,7 @@ def main():
                      roi_subset_robust=args.roi_subset_robust, stats_aggregation=args.stats_aggregation, 
                      remove_small_blobs=args.remove_small_blobs, statistics_normalized_intensities=False,
                      robust_crop=args.robust_crop, higher_order_resampling=args.higher_order_resampling,
-                     save_probabilities=args.save_probabilities, debug=args.debug)
+                     save_probabilities=args.save_probabilities, debug=args.debug, report=args.report)
 
 
 if __name__ == '__main__':

--- a/totalsegmentator/bin/totalseg_aggregate_stats.py
+++ b/totalsegmentator/bin/totalseg_aggregate_stats.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+import sys
+import csv
+import json
+import argparse
+from pathlib import Path
+
+
+def flatten(prefix, value):
+    """Flatten a (possibly nested list) metric value into {column: scalar} pairs.
+
+    Scalars stay as one column; lists are expanded with index suffixes, e.g.
+    centroid_vox -> centroid_vox_0/_1/_2 and bbox_vox -> bbox_vox_0_0/_0_1/...
+    This keeps the output tidy (one scalar per cell) for pandas / R.
+    """
+    if isinstance(value, list):
+        out = {}
+        for i, item in enumerate(value):
+            out.update(flatten(f"{prefix}_{i}", item))
+        return out
+    return {prefix: value}
+
+
+def rows_from_stats(stats, subject):
+    """Turn one statistics.json dict ({structure: {metric: value}}) into tidy rows."""
+    rows = []
+    for structure, metrics in stats.items():
+        row = {"subject": subject, "structure": structure}
+        for metric, value in metrics.items():
+            row.update(flatten(metric, value))
+        rows.append(row)
+    return rows
+
+
+def collect_rows(input_dir, filename, quiet=False):
+    """Find every `filename` under input_dir and return (rows, n_subjects)."""
+    stats_files = sorted(input_dir.rglob(filename))
+    rows = []
+    n_subjects = 0
+    for f in stats_files:
+        try:
+            with open(f) as fh:
+                stats = json.load(fh)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"WARNING: skipping {f} ({e})")
+            continue
+        rel = f.parent.relative_to(input_dir)
+        subject = str(rel) if str(rel) != "." else f.parent.name
+        rows.extend(rows_from_stats(stats, subject))
+        n_subjects += 1
+        if not quiet:
+            print(f"  + {subject}: {len(stats)} structures")
+    return rows, n_subjects
+
+
+def ordered_columns(rows):
+    """Stable column order: subject, structure, then metric columns in first-seen order."""
+    columns = ["subject", "structure"]
+    seen = set(columns)
+    for row in rows:
+        for key in row:
+            if key not in seen:
+                seen.add(key)
+                columns.append(key)
+    return columns
+
+
+def write_table(rows, columns, output):
+    """Write rows to CSV, parquet or JSON, chosen by the output file extension."""
+    suffix = output.suffix.lower()
+    if suffix == ".parquet":
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+        except ImportError:
+            raise ImportError("pyarrow is required for parquet output (`pip install pyarrow`).")
+        table = pa.table({col: [row.get(col) for row in rows] for col in columns})
+        pq.write_table(table, output)
+    elif suffix == ".json":
+        with open(output, "w") as f:
+            json.dump(rows, f, indent=2)
+    else:  # default: CSV
+        with open(output, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=columns)
+            writer.writeheader()
+            writer.writerows(rows)
+
+
+def main():
+    """
+    Aggregate the per-image statistics.json files of a whole cohort into one table.
+
+    TotalSegmentator's `--statistics` writes one statistics.json per image. For a
+    study you usually want a single analysis-ready table across all subjects. This
+    command scans a directory tree for statistics.json files and merges them into
+    one tidy (long) table: one row per (subject, structure), with a column per
+    metric. Output format is chosen by the extension of -o (.csv, .parquet, .json).
+
+    Usage:
+    totalseg_aggregate_stats -i cohort_dir -o cohort_stats.csv
+    totalseg_aggregate_stats -i cohort_dir -o cohort_stats.parquet
+    totalseg_aggregate_stats -i cohort_dir -o radiomics.csv --filename statistics_radiomics.json
+
+    Subject ids are derived from the path of each statistics file relative to the
+    input directory (e.g. cohort_dir/subj001/statistics.json -> "subj001").
+    """
+    parser = argparse.ArgumentParser(
+        description="Aggregate per-image statistics.json files of a cohort into one table.",
+        epilog="Written by Jakob Wasserthal. If you use this tool please cite https://pubs.rsna.org/doi/10.1148/ryai.230024")
+
+    parser.add_argument("-i", metavar="directory", dest="input",
+                        help="Directory containing TotalSegmentator outputs (searched recursively for the statistics file).",
+                        type=lambda p: Path(p).absolute(), required=True)
+
+    parser.add_argument("-o", metavar="filepath", dest="output",
+                        help="Output table path. Format from extension: .csv (default), .parquet or .json.",
+                        type=lambda p: Path(p).absolute(), required=True)
+
+    parser.add_argument("-f", "--filename", type=str, default="statistics.json",
+                        help="Name of the per-image statistics file to look for (default: statistics.json).")
+
+    parser.add_argument("-q", "--quiet", action="store_true", default=False,
+                        help="Print no per-subject output.")
+
+    args = parser.parse_args()
+
+    if not args.input.is_dir():
+        parser.error(f"input directory does not exist: {args.input}")
+
+    rows, n_subjects = collect_rows(args.input, args.filename, quiet=args.quiet)
+    if not rows:
+        print(f"ERROR: no '{args.filename}' files found under {args.input}")
+        sys.exit(2)
+
+    columns = ordered_columns(rows)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    write_table(rows, columns, args.output)
+    print(f"Aggregated {n_subjects} subjects ({len(rows)} rows) -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/totalsegmentator/bin/totalseg_batch.py
+++ b/totalsegmentator/bin/totalseg_batch.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+import sys
+import time
+import argparse
+import traceback
+from pathlib import Path
+
+# Heavy imports (torch / nnunet) are done lazily inside main() so the small helper
+# functions below stay importable (and testable) without a full runtime.
+
+
+def find_images(input_dir, pattern=None):
+    """Find the input images to process in input_dir.
+
+    By default all .nii / .nii.gz files directly inside input_dir. With --pattern,
+    a glob relative to input_dir (e.g. "*/ct.nii.gz") is used instead.
+    """
+    if pattern:
+        return sorted(input_dir.glob(pattern))
+    return sorted(p for p in input_dir.iterdir()
+                  if p.is_file() and (p.name.endswith(".nii") or p.name.endswith(".nii.gz")))
+
+
+def case_id(path):
+    """Derive a case id from an image filename (strip the .nii/.nii.gz suffix)."""
+    name = path.name
+    for suffix in (".nii.gz", ".nii"):
+        if name.endswith(suffix):
+            return name[:-len(suffix)]
+    return path.stem
+
+
+def output_target(output_dir, cid, ml):
+    """Per-case output location. A directory of masks, or a multilabel file when ml=True.
+
+    In both cases statistics.json ends up inside output_dir/<cid>/, so the cohort
+    aggregator can find one statistics file per case.
+    """
+    case_dir = output_dir / cid
+    return case_dir / "segmentation.nii.gz" if ml else case_dir
+
+
+def main():
+    """
+    Run TotalSegmentator over a whole folder of images in one process.
+
+    The model weights are loaded once and reused across all images (instead of being
+    reloaded for every image as in a shell loop), which substantially reduces the
+    runtime for a cohort. Per-image failures are logged and the run continues. If
+    --statistics is set, the per-image statistics are also aggregated into one table.
+
+    Each case is written to <output_dir>/<case_id>/ (case_id is the image filename
+    without its .nii/.nii.gz suffix).
+
+    Usage:
+    totalseg_batch -i ct_folder -o output_folder
+    totalseg_batch -i ct_folder -o output_folder --statistics -ta total -d gpu
+    totalseg_batch -i study_folder -o output_folder --pattern "*/ct.nii.gz"
+    """
+    parser = argparse.ArgumentParser(
+        description="Run TotalSegmentator over a folder of images, loading the model only once.",
+        epilog="Written by Jakob Wasserthal. If you use this tool please cite https://pubs.rsna.org/doi/10.1148/ryai.230024")
+
+    parser.add_argument("-i", metavar="directory", dest="input",
+                        help="Directory containing the input images (.nii/.nii.gz).",
+                        type=lambda p: Path(p).absolute(), required=True)
+    parser.add_argument("-o", metavar="directory", dest="output",
+                        help="Output directory. Each case is written to <output>/<case_id>/.",
+                        type=lambda p: Path(p).absolute(), required=True)
+    parser.add_argument("--pattern", type=str, default=None,
+                        help="Glob (relative to -i) selecting the input images, e.g. '*/ct.nii.gz'. "
+                             "Default: all .nii/.nii.gz files directly inside -i.")
+
+    # Pass-through TotalSegmentator options (the common ones for cohort processing).
+    from totalsegmentator.registry import TASKS
+    parser.add_argument("-ta", "--task", choices=TASKS, metavar="task", default="total",
+                        help="Task to run (default: total). See 'totalseg_info --list-tasks'.")
+    parser.add_argument("-d", "--device", type=str, default="gpu",
+                        help="Device: 'gpu', 'cpu', 'mps' or 'gpu:X'.")
+    parser.add_argument("-f", "--fast", action="store_true", default=False, help="Run faster 3mm model.")
+    parser.add_argument("-ff", "--fastest", action="store_true", default=False, help="Run faster 6mm model.")
+    parser.add_argument("-ml", "--ml", action="store_true", default=False, help="Save one multilabel image per case.")
+    parser.add_argument("-rs", "--roi_subset", type=str, nargs="+", default=None,
+                        help="Only predict this subset of classes.")
+    parser.add_argument("-bs", "--body_seg", action="store_true", default=False,
+                        help="Crop to body region before processing.")
+    parser.add_argument("-s", "--statistics", action="store_true", default=False,
+                        help="Compute statistics.json per case (and aggregate them, see --no_aggregate).")
+    parser.add_argument("-sx", "--statistics_extra", action="store_true", default=False,
+                        help="Add extra per-structure metrics to the statistics.")
+    parser.add_argument("-p", "--preview", action="store_true", default=False, help="Generate a preview png per case.")
+    parser.add_argument("--no_aggregate", action="store_true", default=False,
+                        help="Do not aggregate the per-case statistics into one table.")
+    parser.add_argument("--stop_on_error", action="store_true", default=False,
+                        help="Abort on the first failing image instead of skipping it.")
+    parser.add_argument("-q", "--quiet", action="store_true", default=False, help="Less output per image.")
+
+    args = parser.parse_args()
+
+    if not args.input.is_dir():
+        parser.error(f"input directory does not exist: {args.input}")
+
+    images = find_images(args.input, args.pattern)
+    if not images:
+        sel = f"pattern '{args.pattern}'" if args.pattern else ".nii/.nii.gz files"
+        print(f"ERROR: no {sel} found under {args.input}")
+        sys.exit(2)
+
+    # Lazy heavy imports.
+    from totalsegmentator.python_api import totalsegmentator
+    from totalsegmentator.nnunet import set_predictor_cache_enabled, clear_predictor_cache
+
+    print(f"Found {len(images)} images. Running task '{args.task}' on device '{args.device}'.")
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    errors = []
+    n_ok = 0
+    t0 = time.time()
+    # Load the model once and reuse it for every image.
+    set_predictor_cache_enabled(True)
+    try:
+        for i, image in enumerate(images, start=1):
+            cid = case_id(image)
+            target = output_target(args.output, cid, args.ml)
+            (args.output / cid).mkdir(parents=True, exist_ok=True)
+            print(f"[{i}/{len(images)}] {cid}")
+            try:
+                totalsegmentator(image, target, task=args.task, device=args.device,
+                                 fast=args.fast, fastest=args.fastest, ml=args.ml,
+                                 roi_subset=args.roi_subset, body_seg=args.body_seg,
+                                 statistics=args.statistics, statistics_extra=args.statistics_extra,
+                                 preview=args.preview, quiet=args.quiet)
+                n_ok += 1
+            except Exception as e:  # noqa: BLE001 - one bad image should not abort the cohort
+                errors.append((cid, repr(e)))
+                print(f"  ERROR on {cid}: {e}")
+                if args.stop_on_error:
+                    raise
+                traceback.print_exc()
+    finally:
+        set_predictor_cache_enabled(False)  # also clears the cache and frees GPU memory
+        clear_predictor_cache()
+
+    # Write an error log if anything failed.
+    if errors:
+        error_log = args.output / "batch_errors.log"
+        with open(error_log, "w") as f:
+            for cid, msg in errors:
+                f.write(f"{cid}\t{msg}\n")
+        print(f"{len(errors)} image(s) failed. See {error_log}")
+
+    # Aggregate the per-case statistics into one table.
+    if args.statistics and not args.no_aggregate and n_ok > 0:
+        from totalsegmentator.bin.totalseg_aggregate_stats import collect_rows, ordered_columns, write_table
+        rows, n_subjects = collect_rows(args.output, "statistics.json", quiet=True)
+        if rows:
+            out_table = args.output / "cohort_statistics.csv"
+            write_table(rows, ordered_columns(rows), out_table)
+            print(f"Aggregated statistics for {n_subjects} cases -> {out_table}")
+
+    print(f"Done: {n_ok}/{len(images)} succeeded in {time.time() - t0:.0f}s.")
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/totalsegmentator/bin/totalseg_info.py
+++ b/totalsegmentator/bin/totalseg_info.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+import sys
+import json
+import argparse
+
+from totalsegmentator.registry import (
+    TASKS, list_tasks, get_task_classes, task_registry,
+    format_tasks_table, format_classes_table,
+)
+
+
+def main():
+    """
+    Print machine- and human-readable information about TotalSegmentator's tasks.
+
+    Lists the available segmentation tasks, the anatomical classes each task
+    outputs, the modality (CT/MR) and whether a license is required. Runs
+    instantly: it needs no GPU and downloads no model weights, which makes it a
+    convenient way for scripts and AI coding agents to discover what the tool can
+    do (e.g. valid --roi_subset class names) without reading the source code.
+
+    Usage:
+    totalseg_info --list-tasks
+    totalseg_info --classes -ta total
+    totalseg_info --json                 # full capability registry as JSON
+    totalseg_info --classes -ta total --json
+    """
+    parser = argparse.ArgumentParser(
+        description="Show information about TotalSegmentator's segmentation tasks and classes.",
+        epilog="Written by Jakob Wasserthal. If you use this tool please cite https://pubs.rsna.org/doi/10.1148/ryai.230024")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-lt", "--list-tasks", action="store_true",
+                       help="List all available tasks with modality, license and number of classes.")
+    group.add_argument("-cl", "--classes", action="store_true",
+                       help="List the classes (index -> name) of the task given via --task.")
+
+    parser.add_argument("-ta", "--task", choices=TASKS, metavar="task",
+                        help="Task to show the classes for (used with --classes).")
+
+    parser.add_argument("--json", action="store_true", dest="as_json",
+                        help="Emit output as JSON instead of a human-readable table.")
+
+    args = parser.parse_args()
+
+    # --classes requires a task
+    if args.classes and args.task is None:
+        parser.error("--classes requires --task/-ta (e.g. totalseg_info --classes -ta total)")
+
+    if args.classes:
+        if args.as_json:
+            classes = get_task_classes(args.task)
+            print(json.dumps({str(idx): name for idx, name in classes.items()}, indent=2))
+        else:
+            print(format_classes_table(args.task))
+        return
+
+    if args.list_tasks:
+        if args.as_json:
+            print(json.dumps(list_tasks(), indent=2))
+        else:
+            print(format_tasks_table())
+        return
+
+    # No explicit mode selected.
+    if args.as_json:
+        # Default JSON output is the full capability registry: one call gives an
+        # agent the complete picture (tasks, modalities, license flags, classes).
+        print(json.dumps(task_registry(), indent=2))
+        return
+
+    # Default human output: the task overview, plus a hint for the other modes.
+    print(format_tasks_table())
+    print()
+    print("Use '--classes -ta <task>' to list a task's classes, or '--json' for machine-readable output.")
+
+
+if __name__ == "__main__":
+    main()

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -90,6 +90,33 @@ warnings.filterwarnings("ignore", category=UserWarning, module="nnunetv2")
 warnings.filterwarnings("ignore", category=FutureWarning, module="nnunetv2")  # ignore torch.load warning
 
 
+# Optional cache of initialized nnUNetPredictor objects, keyed by the parameters that
+# determine the loaded model. Initializing a predictor (loading the network weights from
+# disk) is the expensive part; the prediction itself is unchanged. The cache is OFF by
+# default, so single-image runs behave exactly as before. Batch processing turns it on
+# (see totalseg_batch) so the weights are loaded once and reused across all images.
+_PREDICTOR_CACHE = {}
+_PREDICTOR_CACHE_ENABLED = False
+
+
+def set_predictor_cache_enabled(enabled: bool = True):
+    """Enable/disable reuse of initialized predictors across predictions.
+
+    Disabling also clears the cache so model weights are freed.
+    """
+    global _PREDICTOR_CACHE_ENABLED
+    _PREDICTOR_CACHE_ENABLED = enabled
+    if not enabled:
+        clear_predictor_cache()
+
+
+def clear_predictor_cache():
+    """Drop all cached predictors and free the associated GPU memory."""
+    _PREDICTOR_CACHE.clear()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 def get_full_task_name(task_id: int, src: str="raw"):
     if src == "raw":
         base = Path(os.environ['nnUNet_raw_data_base']) / "nnUNet_raw_data"
@@ -276,35 +303,44 @@ def nnUNetv2_predict(dir_in, dir_out, task_id, model="3d_fullres", folds=None,
     #                       part_id=part_id,
     #                       device=device)
 
-    # nnUNet 2.2.1
-    if supports_keyword_argument(nnUNetPredictor, "perform_everything_on_gpu"):
-        predictor = nnUNetPredictor(
-            tile_step_size=step_size,
-            use_gaussian=True,
-            use_mirroring=not disable_tta,
-            perform_everything_on_gpu=True,  # for nnunetv2<=2.2.1
-            device=device,
-            verbose=verbose,
-            verbose_preprocessing=verbose,
-            allow_tqdm=allow_tqdm
+    # Reuse an already-initialized predictor if caching is enabled (batch mode). The cache
+    # key captures everything that determines the loaded model and the prediction settings.
+    cache_key = (model_folder, tuple(folds) if folds is not None else None,
+                 str(device), step_size, disable_tta, allow_tqdm)
+    predictor = _PREDICTOR_CACHE.get(cache_key) if _PREDICTOR_CACHE_ENABLED else None
+
+    if predictor is None:
+        # nnUNet 2.2.1
+        if supports_keyword_argument(nnUNetPredictor, "perform_everything_on_gpu"):
+            predictor = nnUNetPredictor(
+                tile_step_size=step_size,
+                use_gaussian=True,
+                use_mirroring=not disable_tta,
+                perform_everything_on_gpu=True,  # for nnunetv2<=2.2.1
+                device=device,
+                verbose=verbose,
+                verbose_preprocessing=verbose,
+                allow_tqdm=allow_tqdm
+            )
+        # nnUNet >= 2.2.2
+        else:
+            predictor = nnUNetPredictor(
+                tile_step_size=step_size,
+                use_gaussian=True,
+                use_mirroring=not disable_tta,
+                perform_everything_on_device=True,  # for nnunetv2>=2.2.2
+                device=device,
+                verbose=verbose,
+                verbose_preprocessing=verbose,
+                allow_tqdm=allow_tqdm
+            )
+        predictor.initialize_from_trained_model_folder(
+            model_folder,
+            use_folds=folds,
+            checkpoint_name=chk,
         )
-    # nnUNet >= 2.2.2
-    else:
-        predictor = nnUNetPredictor(
-            tile_step_size=step_size,
-            use_gaussian=True,
-            use_mirroring=not disable_tta,
-            perform_everything_on_device=True,  # for nnunetv2>=2.2.2
-            device=device,
-            verbose=verbose,
-            verbose_preprocessing=verbose,
-            allow_tqdm=allow_tqdm
-        )
-    predictor.initialize_from_trained_model_folder(
-        model_folder,
-        use_folds=folds,
-        checkpoint_name=chk,
-    )
+        if _PREDICTOR_CACHE_ENABLED:
+            _PREDICTOR_CACHE[cache_key] = predictor
     # new nnunetv2 feature: keep dir_out empty to return predictions as return value
     predictor.predict_from_files(dir_in, dir_out,
                                  save_probabilities=save_probabilities, overwrite=not continue_prediction,

--- a/totalsegmentator/python_api.py
+++ b/totalsegmentator/python_api.py
@@ -158,7 +158,7 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
                      v1_order=False, fastest=False, roi_subset_robust=None, stats_aggregation="mean",
                      remove_small_blobs=False, statistics_normalized_intensities=False,
                      robust_crop=False, higher_order_resampling=False, save_probabilities=None,
-                     debug=False, report=None):
+                     debug=False, report=None, statistics_extra=False):
     """
     Run TotalSegmentator from within python.
 
@@ -892,11 +892,12 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
             stats_file = stats_dir / "statistics.json"
         else:
             stats_file = None
-        stats = get_basic_statistics(seg, ct_img, stats_file, 
+        stats = get_basic_statistics(seg, ct_img, stats_file,
                                      quiet, task, statistics_exclude_masks_at_border,
-                                     roi_subset, 
+                                     roi_subset,
                                      metric=stats_aggregation,
-                                     normalized_intensities=statistics_normalized_intensities)
+                                     normalized_intensities=statistics_normalized_intensities,
+                                     extra_metrics=statistics_extra)
         # get_radiomics_features_for_entire_dir(input, output, output / "statistics_radiomics.json")
         if not quiet: print(f"  calculated in {time.time()-st:.2f}s")
 

--- a/totalsegmentator/python_api.py
+++ b/totalsegmentator/python_api.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import json
+import importlib.metadata
 from pathlib import Path
 import time
 import textwrap
@@ -72,6 +74,60 @@ def select_device(device):
     return device
 
 
+def device_to_str(device):
+    """Normalize a device value (torch.device or string) to 'gpu'/'cpu'/'mps' for reporting."""
+    if hasattr(device, "type"):  # torch.device object
+        return "gpu" if device.type == "cuda" else device.type
+    return str(device)
+
+
+def build_run_report(input, output, task, device, fast, fastest, ml, output_type,
+                     roi_subset, runtime_seconds):
+    """Assemble a machine-readable manifest describing a completed run.
+
+    Pure function (no side effects): captures software versions, the resolved
+    device, the run options, the classes produced (filtered by roi_subset when
+    set) and the files written to the output directory. Used by the
+    `--report` CLI option so that automation can verify and chain runs without
+    parsing stdout.
+    """
+    from totalsegmentator.registry import task_modality, get_task_classes, requires_license, package_version
+
+    try:
+        nnunet_version = importlib.metadata.version("nnunetv2")
+    except importlib.metadata.PackageNotFoundError:
+        nnunet_version = None
+
+    classes = get_task_classes(task)
+    if roi_subset:
+        classes = {idx: name for idx, name in classes.items() if name in roi_subset}
+
+    output_files = []
+    if output is not None and Path(output).is_dir():
+        output_files = sorted(p.name for p in Path(output).glob("*.nii.gz"))
+
+    return {
+        "totalsegmentator_version": package_version(),
+        "nnunetv2_version": nnunet_version,
+        "torch_version": torch.__version__,
+        "task": task,
+        "modality": task_modality(task),
+        "license_required": requires_license(task),
+        "device": device_to_str(device),
+        "fast": fast,
+        "fastest": fastest,
+        "multilabel": ml,
+        "output_type": output_type,
+        "roi_subset": roi_subset,
+        "input": "Nifti1Image" if isinstance(input, Nifti1Image) else str(input),
+        "output": None if output is None else str(output),
+        "num_classes": len(classes),
+        "classes": {str(idx): name for idx, name in classes.items()},
+        "runtime_seconds": round(runtime_seconds, 2),
+        "output_files": output_files,
+    }
+
+
 def show_license_info():
     status, message = has_valid_license_offline()
     if status == "missing_license":
@@ -100,9 +156,9 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
                      skip_saving=False, device="gpu", license_number=None,
                      statistics_exclude_masks_at_border=True, no_derived_masks=False,
                      v1_order=False, fastest=False, roi_subset_robust=None, stats_aggregation="mean",
-                     remove_small_blobs=False, statistics_normalized_intensities=False, 
+                     remove_small_blobs=False, statistics_normalized_intensities=False,
                      robust_crop=False, higher_order_resampling=False, save_probabilities=None,
-                     debug=False):
+                     debug=False, report=None):
     """
     Run TotalSegmentator from within python.
 
@@ -111,6 +167,7 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
 
     Return: multilabel Nifti1Image
     """
+    run_start = time.time()
     if not isinstance(input, Nifti1Image):
         input = Path(input)
 
@@ -859,6 +916,15 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
                 input_path = input
             get_radiomics_features_for_entire_dir(input_path, output, stats_dir / "statistics_radiomics.json")
             if not quiet: print(f"  calculated in {time.time()-st:.2f}s")
+
+    if report is not None:
+        report_data = build_run_report(input, output, task, device, fast, fastest, ml,
+                                       output_type, roi_subset, time.time() - run_start)
+        report_path = Path(report).absolute()
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(report_path, "w") as f:
+            json.dump(report_data, f, indent=2)
+        if not quiet: print(f"Run report written to {report_path}")
 
     # Restore initial torch settings
     torch.backends.cudnn.benchmark = initial_cudnn_benchmark

--- a/totalsegmentator/registry.py
+++ b/totalsegmentator/registry.py
@@ -1,0 +1,122 @@
+"""
+Machine-readable registry of TotalSegmentator's segmentation tasks.
+
+This module is the single source of truth for which segmentation tasks exist,
+which anatomical classes each one outputs, whether it requires a license and
+whether it operates on CT or MR images.
+
+It intentionally only depends on the pure-data maps in ``map_to_binary`` (no
+torch, no model weights), so it can be imported and queried instantly. This
+powers the ``totalseg_info`` command and the ``--list-tasks`` / ``--list-classes``
+flags of the main CLI, letting humans and automation discover the tool's
+capabilities without reading the source code.
+"""
+import importlib.metadata
+
+from totalsegmentator.map_to_binary import class_map, commercial_models
+
+
+# Selectable tasks, in the order they are offered on the command line.
+# bin/TotalSegmentator.py imports this list for its --task choices so the two
+# can never drift apart.
+TASKS = [
+    "total", "body", "body_mr", "vertebrae_mr",
+    "lung_vessels", "lung_vessels_LEGACY", "cerebral_bleed", "hip_implant",
+    "coronary_arteries", "coronary_arteries_LEGACY",
+    "pleural_pericard_effusion", "test",
+    "appendicular_bones", "appendicular_bones_mr", "tissue_types", "heartchambers_highres",
+    "face", "vertebrae_body", "total_mr", "tissue_types_mr", "tissue_4_types", "face_mr",
+    "head_glands_cavities", "head_muscles", "headneck_bones_vessels", "headneck_muscles",
+    "brain_structures", "liver_vessels", "liver_lesions", "liver_lesions_mr", "oculomotor_muscles",
+    "thigh_shoulder_muscles", "thigh_shoulder_muscles_mr", "lung_nodules", "kidney_cysts",
+    "breasts", "ventricle_parts", "aortic_sinuses", "liver_segments", "liver_segments_mr",
+    "total_highres_test", "craniofacial_structures", "abdominal_muscles", "teeth",
+    "trunk_cavities", "brain_aneurysm",
+]
+
+# Tasks that operate on MR images but whose name does not end in "_mr".
+_MR_TASKS_WITHOUT_SUFFIX = {"brain_aneurysm"}  # TOF-MRI only
+
+
+def package_version():
+    """Installed TotalSegmentator version, or None if not installed (e.g. run from source)."""
+    try:
+        return importlib.metadata.version("TotalSegmentator")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def task_modality(task):
+    """Return "MR" or "CT" for a task name."""
+    if task.endswith("_mr") or task in _MR_TASKS_WITHOUT_SUFFIX:
+        return "MR"
+    return "CT"
+
+
+def requires_license(task):
+    """Whether the task needs a license (free for non-commercial use)."""
+    return task in commercial_models
+
+
+def get_task_classes(task):
+    """Return the {label_index: class_name} map a task outputs.
+
+    Raises KeyError for an unknown task.
+    """
+    try:
+        return dict(class_map[task])
+    except KeyError:
+        raise KeyError(f"Unknown task: {task!r}. Valid tasks: {', '.join(TASKS)}")
+
+
+def list_tasks():
+    """Summary of every selectable task: name, modality, license flag, #classes."""
+    return [
+        {
+            "name": t,
+            "modality": task_modality(t),
+            "license_required": requires_license(t),
+            "num_classes": len(get_task_classes(t)),
+        }
+        for t in TASKS
+    ]
+
+
+def task_registry():
+    """Full machine-readable capability map for all selectable tasks (JSON-serializable)."""
+    return {
+        "totalsegmentator_version": package_version(),
+        "tasks": {
+            t: {
+                "modality": task_modality(t),
+                "license_required": requires_license(t),
+                "classes": {str(idx): name for idx, name in get_task_classes(t).items()},
+            }
+            for t in TASKS
+        },
+    }
+
+
+def format_tasks_table():
+    """Human-readable table of all tasks (used by totalseg_info and --list-tasks)."""
+    rows = list_tasks()
+    name_w = max(len("TASK"), max(len(r["name"]) for r in rows))
+    header = f"{'TASK'.ljust(name_w)}  MODALITY  LICENSE  CLASSES"
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        lic = "yes" if r["license_required"] else "no"
+        lines.append(f"{r['name'].ljust(name_w)}  {r['modality'].ljust(8)}  {lic.ljust(7)}  {r['num_classes']}")
+    lines.append("")
+    lines.append(f"{len(rows)} tasks. Licensed tasks need a (free for non-commercial) license: "
+                 "https://backend.totalsegmentator.com/license-academic/")
+    return "\n".join(lines)
+
+
+def format_classes_table(task):
+    """Human-readable index->name listing of the classes a task outputs."""
+    classes = get_task_classes(task)
+    lic = "license required" if requires_license(task) else "open license"
+    lines = [f"Task '{task}'  [{task_modality(task)}, {lic}, {len(classes)} classes]", ""]
+    for idx in sorted(classes):
+        lines.append(f"{str(idx).rjust(4)}  {classes[idx]}")
+    return "\n".join(lines)

--- a/totalsegmentator/statistics.py
+++ b/totalsegmentator/statistics.py
@@ -88,17 +88,51 @@ def touches_border(mask):
     return False
 
 
-def get_basic_statistics(seg: np.array, 
-                         ct_file: Union[Path, Nifti1Image], 
-                         file_out: Union[Path, None]=None, 
+def _empty_extra_metrics(target):
+    target["n_voxels"] = 0
+    target["intensity_std"] = 0.0
+    target["intensity_min"] = 0.0
+    target["intensity_max"] = 0.0
+    target["centroid_vox"] = None
+    target["bbox_vox"] = None
+
+
+def _add_extra_metrics(target, data, ct):
+    """Add morphometric + intensity-distribution metrics for one structure.
+
+    centroid_vox and bbox_vox are in voxel/index coordinates (numpy axes i,j,k);
+    bbox_vox is [[i_min,i_max],[j_min,j_max],[k_min,k_max]] with inclusive maxima.
+    """
+    idx = np.argwhere(data)
+    if idx.shape[0] == 0:
+        _empty_extra_metrics(target)
+        return
+    vals = ct[data]
+    target["n_voxels"] = int(idx.shape[0])
+    target["intensity_std"] = float(np.std(vals).round(5))
+    target["intensity_min"] = float(vals.min())
+    target["intensity_max"] = float(vals.max())
+    target["centroid_vox"] = [round(float(c), 2) for c in idx.mean(axis=0)]
+    target["bbox_vox"] = [[int(idx[:, a].min()), int(idx[:, a].max())] for a in range(idx.shape[1])]
+
+
+def get_basic_statistics(seg: np.array,
+                         ct_file: Union[Path, Nifti1Image],
+                         file_out: Union[Path, None]=None,
                          quiet: bool=False,
-                         task: str="total", 
+                         task: str="total",
                          exclude_masks_at_border: bool=True,
                          roi_subset: list=None,
                          metric: str="mean",
-                         normalized_intensities: bool=False):
+                         normalized_intensities: bool=False,
+                         extra_metrics: bool=False):
     """
     ct_file: path to a ct_file or a nifti file object
+
+    extra_metrics: in addition to volume and intensity, also compute
+        n_voxels, intensity_std/min/max and the morphometric centroid_vox and
+        bbox_vox (both in voxel/index coordinates). Off by default to keep the
+        default runtime unchanged.
     """
     ct_img = nib.load(ct_file) if isinstance(ct_file, (str, Path)) else ct_file
     ct = ct_img.get_fdata().astype(np.int16)
@@ -121,6 +155,8 @@ def get_basic_statistics(seg: np.array,
             # print(f"WARNING: {mask_name} touches border. Skipping.")
             stats[mask_name]["volume"] = 0.0
             stats[mask_name]["intensity"] = 0.0
+            if extra_metrics:
+                _empty_extra_metrics(stats[mask_name])
         else:
             stats[mask_name]["volume"] = data.sum() * vox_vol  # vol in mm3; 0.2s
             roi_mask = (data > 0).astype(np.uint8)  # 0.16s
@@ -131,6 +167,8 @@ def get_basic_statistics(seg: np.array,
             elif metric == "median":
                 stats[mask_name]["intensity"] = np.median(ct[roi_mask > 0]).round(5) if roi_mask.sum() > 0 else 0.0  # 0.9s  # fast lowres mode: 0.014s
             # print(f"took: {time.time()-st:.4f}s")
+            if extra_metrics:
+                _add_extra_metrics(stats[mask_name], data, ct)
 
     if file_out is not None:
         with open(file_out, "w") as f:


### PR DESCRIPTION
> **Draft / stacked on #579.** This branch builds on #579 (it reuses `totalseg_aggregate_stats` and the predictor-cache lives alongside that work), so its diff currently includes #579's commits. Please review/merge #579 first; the batch-specific changes are the last two commits (`Add batch processing with amortized model loading`, `Document and test batch processing`). Happy to rebase onto a clean master once #579 is merged.

## Motivation

Processing a cohort today means calling `TotalSegmentator` once per image in a shell loop, which **reloads the model weights for every image**. On a study of hundreds of scans that overhead dominates. This PR lets you process a whole folder while loading the model only once.

## Approach (and why it's safe)

The expensive step is `nnUNetPredictor.initialize_from_trained_model_folder` (loading the network from disk); the prediction itself is unchanged. So instead of restructuring the inference pipeline, this adds an **opt-in cache of initialized predictors** in `nnunet.py`, keyed by the parameters that determine the loaded model:

- The cache is **off by default**, so single-image runs are byte-identical to before — the prediction math is untouched, only the weight-load is skipped on reuse.
- `set_predictor_cache_enabled()` / `clear_predictor_cache()` turn it on for a batch and free GPU memory afterwards.

This keeps all the per-image logic (resampling, cropping models, cascades, derived masks) exactly as-is.

## New command

```bash
totalseg_batch -i ct_folder -o out_folder --statistics -ta total -d gpu
```

- Processes every `.nii/.nii.gz` in the folder (or a `--pattern` glob), writing each case to `out_folder/<case_id>/`.
- Per-image failures are logged to `batch_errors.log` and the run continues (unless `--stop_on_error`); the command exits non-zero if any image failed.
- With `--statistics`, the per-case statistics are aggregated into `out_folder/cohort_statistics.csv`.

## Testing

- `tests/test_batch.py` covers the input-discovery and output-path helpers (no GPU/model).
- `tests/tests.sh` runs `totalseg_batch` on a one-image folder and asserts its output is **identical** (`np.array_equal`) to the normal single-image run with the same options — directly verifying that the cached-predictor path does not change predictions. The existing reference-dice tests continue to exercise the default (cache-off) path.
- `ruff check` passes on all changed files.

## Open questions for the maintainer

- Is a separate `totalseg_batch` command preferable, or would you rather expose this as a `--batch`/folder mode on the main command?
- The per-case output layout (`out_folder/<case_id>/`) — does that match how you'd want cohort outputs organized?