### PR TITLE
Fix #589: derive totalseg_download_weights --task choices from the task table

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -10,6 +10,7 @@ from totalsegmentator.registry import (
     list_tasks, task_registry, format_tasks_table, format_classes_table,
 )
 from totalsegmentator.map_to_binary import commercial_models
+from totalsegmentator.bin import totalseg_download_weights as download_weights
 
 
 class TestRegistry(unittest.TestCase):
@@ -156,3 +157,41 @@ class TestRunReport(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDownloadWeightsTasks(unittest.TestCase):
+    """`totalseg_download_weights -t <task>` must accept every task it can download.
+
+    The --task choices and the task->dataset-id table used to be maintained by hand
+    as two separate lists, and drifted: six downloadable tasks were rejected by
+    argparse (issue #589). The choices are now derived from the table, and this test
+    pins that they cannot diverge again.
+    """
+
+    def test_every_downloadable_task_is_accepted_by_the_cli(self):
+        parser = download_weights.build_parser()
+        for task in download_weights.TASK_TO_ID:
+            self.assertEqual(parser.parse_args(["-t", task]).task, task)
+
+    def test_every_accepted_task_resolves_to_dataset_ids(self):
+        # The inverse direction: argparse must not accept a task the download step
+        # would then KeyError on.
+        parser = download_weights.build_parser()
+        accepted = parser._option_string_actions["--task"].choices
+        for task in accepted:
+            if task == "all":
+                continue
+            self.assertIn(task, download_weights.TASK_TO_ID)
+            self.assertTrue(download_weights.TASK_TO_ID[task],
+                            f"task '{task}' maps to no dataset id")
+
+    def test_all_is_still_selectable(self):
+        self.assertEqual(download_weights.build_parser().parse_args(["-t", "all"]).task, "all")
+
+    def test_default_is_total(self):
+        self.assertEqual(download_weights.build_parser().parse_args([]).task, "total")
+
+    def test_regression_issue_589_brain_aneurysm(self):
+        parser = download_weights.build_parser()
+        self.assertEqual(parser.parse_args(["-t", "brain_aneurysm"]).task, "brain_aneurysm")
+        self.assertEqual(download_weights.TASK_TO_ID["brain_aneurysm"], [615])

--- a/totalsegmentator/bin/totalseg_download_weights.py
+++ b/totalsegmentator/bin/totalseg_download_weights.py
@@ -8,97 +8,89 @@ from totalsegmentator.libs import download_pretrained_weights
 from totalsegmentator.config import setup_totalseg, set_config_key
 
 
+# Maps each downloadable task to the nnU-Net dataset id(s) its weights live in.
+# The --task choices below are derived from this dict, so a task can never be
+# downloadable via the Python API yet rejected by the command line.
+TASK_TO_ID = {
+    "total": [291, 292, 293, 294, 295, 298],
+    "total_fast": [297, 298],
+    "total_v3": [831, 832, 833, 834, 835, 837],
+    "total_v3_fast": [836, 837],
+    "total_mr": [850, 851],
+    "total_fast_mr": [852, 853],
+    "lung_vessels": [117],
+    "lung_vessels_LEGACY": [258],
+    "cerebral_bleed": [150],
+    "hip_implant": [260],
+    "pleural_pericard_effusion": [315],
+    "body": [299],
+    "body_fast": [300],
+    "body_mr": [597],
+    "body_mr_fast": [598],
+    "vertebrae_mr": [756],
+    "head_glands_cavities": [775],
+    "headneck_bones_vessels": [776],
+    "head_muscles": [777],
+    "headneck_muscles": [778, 779],
+    "liver_vessels": [8],
+    "lung_nodules": [913],
+    "kidney_cysts": [789],
+    "oculomotor_muscles": [351],
+    "breasts": [527],
+    "ventricle_parts": [552],
+    "liver_segments": [570],
+    "liver_segments_mr": [576],
+    "liver_lesions": [591],
+    "liver_lesions_mr": [589],
+    "craniofacial_structures": [115],
+    "abdominal_muscles": [952],
+    "teeth": [113],
+    "trunk_cavities": [343],
+    "brain_aneurysm": [615],
+    
+    "heartchambers_highres": [301],
+    "appendicular_bones": [304],
+    "appendicular_bones_mr": [855],
+    "tissue_types": [481],
+    "tissue_types_mr": [925],
+    "tissue_4_types": [485],
+    "vertebrae_body": [305],
+    "vertebrae_pp": [803],
+    "vertebrae_pp_refined": [803, 305],
+    "face": [303],
+    "face_mr": [856],
+    "brain_structures": [409],
+    "thigh_shoulder_muscles": [857],
+    "thigh_shoulder_muscles_mr": [857],
+    "coronary_arteries": [509],
+    "coronary_arteries_LEGACY": [507],
+    "body_stats": ["body_stats"],
+    "body_stats_cnn_mr": ["body_stats_cnn_mr"],
+    "body_stats_cnn_ct": ["body_stats_cnn_ct"],
+    "aortic_sinuses": [920],
+    "renal_arteries": [710],
+    "aorta_annulus": [713],
+    "aortic_dissection": [716],
+    "pulmonary_artery_landmarks": [514],
+}
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Import manually downloaded weights.",
+                                     epilog="Written by Jakob Wasserthal.")
+
+    parser.add_argument("-t", "--task", choices=sorted(TASK_TO_ID) + ["all"],
+                        help="Task for which to download the weights", default="total")
+
+    return parser
+
+
 def main():
     """
     Download totalsegmentator weights
 
     Info: If want to download models with require a license you have to run `totalseg_set_license` first.
     """
-    parser = argparse.ArgumentParser(description="Import manually downloaded weights.",
-                                     epilog="Written by Jakob Wasserthal.")
-
-    parser.add_argument("-t", "--task", choices=["total", "total_fast", "total_v3", "total_v3_fast", "total_mr", "total_fast_mr",
-                                                 "lung_vessels", "lung_vessels_LEGACY", "cerebral_bleed",
-                                                 "hip_implant", "coronary_arteries", "coronary_arteries_LEGACY", "pleural_pericard_effusion",
-                                                 "body", "body_fast", "body_mr", "body_mr_fast", "vertebrae_mr",
-                                                 "vertebrae_body", "vertebrae_pp", "vertebrae_pp_refined",
-                                                 "heartchambers_highres", "appendicular_bones", "appendicular_bones_mr",
-                                                 "tissue_types", "tissue_types_mr", "tissue_4_types", "face", "face_mr",
-                                                 "head_glands_cavities", "head_muscles", "headneck_bones_vessels",
-                                                 "headneck_muscles", "liver_vessels", "brain_structures",
-                                                 "lung_nodules", "kidney_cysts", "breasts", "ventricle_parts",
-                                                 "thigh_shoulder_muscles", "thigh_shoulder_muscles_mr", 
-                                                 "liver_segments", "liver_segments_mr", "liver_lesions", "liver_lesions_mr",
-                                                 "body_stats", "body_stats_cnn_mr", "body_stats_cnn_ct",
-                                                 "aortic_sinuses", "renal_arteries", "aorta_annulus", "aortic_dissection",
-                                                 "pulmonary_artery_landmarks",
-                                                 "all"],
-                        help="Task for which to download the weights", default="total")
-
-    args = parser.parse_args()
-
-    task_to_id = {
-        "total": [291, 292, 293, 294, 295, 298],
-        "total_fast": [297, 298],
-        "total_v3": [831, 832, 833, 834, 835, 837],
-        "total_v3_fast": [836, 837],
-        "total_mr": [850, 851],
-        "total_fast_mr": [852, 853],
-        "lung_vessels": [117],
-        "lung_vessels_LEGACY": [258],
-        "cerebral_bleed": [150],
-        "hip_implant": [260],
-        "pleural_pericard_effusion": [315],
-        "body": [299],
-        "body_fast": [300],
-        "body_mr": [597],
-        "body_mr_fast": [598],
-        "vertebrae_mr": [756],
-        "head_glands_cavities": [775],
-        "headneck_bones_vessels": [776],
-        "head_muscles": [777],
-        "headneck_muscles": [778, 779],
-        "liver_vessels": [8],
-        "lung_nodules": [913],
-        "kidney_cysts": [789],
-        "oculomotor_muscles": [351],
-        "breasts": [527],
-        "ventricle_parts": [552],
-        "liver_segments": [570],
-        "liver_segments_mr": [576],
-        "liver_lesions": [591],
-        "liver_lesions_mr": [589],
-        "craniofacial_structures": [115],
-        "abdominal_muscles": [952],
-        "teeth": [113],
-        "trunk_cavities": [343],
-        "brain_aneurysm": [615],
-        
-        "heartchambers_highres": [301],
-        "appendicular_bones": [304],
-        "appendicular_bones_mr": [855],
-        "tissue_types": [481],
-        "tissue_types_mr": [925],
-        "tissue_4_types": [485],
-        "vertebrae_body": [305],
-        "vertebrae_pp": [803],
-        "vertebrae_pp_refined": [803, 305],
-        "face": [303],
-        "face_mr": [856],
-        "brain_structures": [409],
-        "thigh_shoulder_muscles": [857],
-        "thigh_shoulder_muscles_mr": [857],
-        "coronary_arteries": [509],
-        "coronary_arteries_LEGACY": [507],
-        "body_stats": ["body_stats"],
-        "body_stats_cnn_mr": ["body_stats_cnn_mr"],
-        "body_stats_cnn_ct": ["body_stats_cnn_ct"],
-        "aortic_sinuses": [920],
-        "renal_arteries": [710],
-        "aorta_annulus": [713],
-        "aortic_dissection": [716],
-        "pulmonary_artery_landmarks": [514],
-    }
+    args = build_parser().parse_args()
 
     setup_totalseg()
     set_config_key("statistics_disclaimer_shown", True)
@@ -106,7 +98,7 @@ def main():
     if args.task == "all":
         # Get unique task IDs from all tasks
         all_task_ids = set()
-        for task_ids in task_to_id.values():
+        for task_ids in TASK_TO_ID.values():
             if isinstance(task_ids, list):
                 all_task_ids.update(task_ids)
             else:
@@ -116,7 +108,7 @@ def main():
             print(f"Processing {task_id}...")
             download_pretrained_weights(task_id)
     else:
-        for task_id in task_to_id[args.task]:
+        for task_id in TASK_TO_ID[args.task]:
             print(f"Processing {task_id}...")
             download_pretrained_weights(task_id)
 


### PR DESCRIPTION
Fixes #589.

`totalseg_download_weights -t brain_aneurysm` fails with `invalid choice` even though the task is supported and already present in `task_to_id`.

## Root cause

The argparse `choices` list and the `task_to_id` dict were two hand-maintained copies of the same information, and they had drifted apart. `brain_aneurysm` was not the only casualty — **six** downloadable tasks were unreachable from the command line:

| task | dataset id |
|---|---|
| `abdominal_muscles` | 952 |
| `brain_aneurysm` | 615 |
| `craniofacial_structures` | 115 |
| `oculomotor_muscles` | 351 |
| `teeth` | 113 |
| `trunk_cavities` | 343 |

## Change

Rather than adding the six missing strings (which leaves the same trap for the next task), this lifts the table to a module-level `TASK_TO_ID` and derives the choices from it:

```python
parser.add_argument("-t", "--task", choices=sorted(TASK_TO_ID) + ["all"], ...)
```

So a task can no longer be downloadable via the Python API yet rejected by the CLI. Selectable tasks go from 54 to 60. The default stays `total`, and `all` still works.

The parser is also extracted into `build_parser()` so it can be tested without triggering a download.

## Tests

`tests/test_registry.py` gains five cases pinning both directions of the invariant:

- every task in `TASK_TO_ID` is accepted by the CLI
- every task the CLI accepts resolves to non-empty dataset ids (so the lookup cannot `KeyError`)
- `all` is still selectable, default is still `total`
- an explicit regression case for `brain_aneurysm` / #589

These are pure-data tests — no GPU, no torch, no weights — so they run in the existing `pytest -v tests/test_registry.py` step in `tests.sh`.

```
19 passed in 1.12s
```

Verified before/after: upstream `master` rejects `brain_aneurysm` (54 choices); with this change all six previously-rejected tasks parse and map to the correct dataset ids.