### PR TITLE
Fix DICOM SEG anterior/posterior mirror for negated axial orientation

### DIFF
--- a/totalsegmentator/dicom_io.py
+++ b/totalsegmentator/dicom_io.py
@@ -569,8 +569,22 @@ def save_mask_as_dicomseg(img_data, selected_classes, dcm_reference_file, output
 
     # 1) DICOM has orientation (rows, cols, slices), while HIGHDICOM expects (slices, rows, cols)
     # 2) Flip along x and z axes to correct coordinate system difference between DICOM and HIGHDICOM
+    #
+    # The axial row flip below assumes the conventional column direction cosine
+    # [0, 1, 0] ("top of image = anterior"). Some DICOM series have it negated,
+    # [0, -1, 0] ("top of image = posterior") -- for those the same unconditional
+    # flip mirrors the segmentation anterior/posterior. Use the actual direction
+    # cosines (already extracted above) rather than the coarse plane label to
+    # decide whether the flip is needed.
+    axial_row_flip_needed = True
+    iop = orientation_metadata.get("image_orientation_patient")
+    if iop is not None and len(iop) == 6:
+        axial_row_flip_needed = iop[4] >= 0
+
     if orientation_metadata.get("plane") == "axial":
-        img_data = xp.transpose(img_data, (2, 0, 1))[:, ::-1, :]
+        img_data = xp.transpose(img_data, (2, 0, 1))
+        if axial_row_flip_needed:
+            img_data = img_data[:, ::-1, :]
     elif orientation_metadata.get("plane") == "coronal":
         img_data = xp.transpose(img_data, (2, 1, 0))[::-1, ::-1, :]
     elif orientation_metadata.get("plane") == "sagittal":


### PR DESCRIPTION
## Summary

`save_mask_as_dicomseg`'s axial branch unconditionally flips the row axis to
reconcile a DICOM-vs-highdicom axis convention difference:

```python
if orientation_metadata.get("plane") == "axial":
    img_data = xp.transpose(img_data, (2, 0, 1))[:, ::-1, :]
```

That flip is only correct for the conventional axial column direction cosine
`[0, 1, 0]` ("top of image = anterior"). Some DICOM series (seen in
anonymised TCIA data) have it negated, `[0, -1, 0]` ("top of image =
posterior") instead — for those, the same unconditional flip mirrors the
written segmentation front-to-back along the anterior-posterior axis.

## How this was found and confirmed

Comparing each organ's centroid computed two independent ways for the same
scan:
1. From the written DICOM SEG's own per-frame geometry (`ImagePositionPatient`
   + `ImageOrientationPatient` + `PixelSpacing`, decoded per-frame)
2. From the source segmentation mask's own affine (independently verified
   anatomically correct — paired organs on the correct side, expected
   anterior/posterior and superior/inferior ordering)

Left/right and superior/inferior matched exactly; anterior/posterior differed
by the same constant for every organ (`y_seg = 359.297 - y_mask`, i.e. exactly
the image height in mm minus one pixel) — a pixel-perfect mirror, not a
misalignment.

## Fix

Use the actual direction cosines (`image_orientation_patient`, already present
in `orientation_metadata`) instead of the coarse `"axial"/"coronal"/"sagittal"`
plane label to decide whether the row flip is needed. Only the axial branch is
touched — coronal/sagittal are left as-is since this is the one case confirmed
affected by real data.

## Verification

- Reproduced the bug and verified the fix on 2 real, anonymised CT series
  (TCIA Pancreas-CT) with `ImageOrientationPatient = [1,0,0,0,-1,0]`: centroid
  agreement went from up to ~74 mm mirrored to **0.0 mm difference** across 6
  laterally/anatomically unambiguous organs each (kidneys, liver, spleen,
  autochthon muscles).
- Confirmed the fix does not change output for the conventional orientation:
  the flip condition reduces to the previous unconditional behaviour whenever
  the column direction is not negated (`iop[4] >= 0`), which is exactly the
  old code path.
- This repo's `tests/` has no existing coverage for `save_mask_as_dicomseg`,
  so I didn't want to invent new test infrastructure/fixtures as part of a
  small bug-fix PR — happy to add a regression test here too if maintainers
  have a preferred pattern for DICOM-writing tests (e.g. a synthetic minimal
  series). I do have one downstream, if useful as a reference.

## Context

This is the same function fixed in #567 (a crash on stripped `SliceThickness`
in anonymised DICOM) — another case of an anonymisation-related edge case in
DICOM handling here.
