### PR TITLE
Add --torch-resample: run the forward image resample through torch

### DIFF
--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,0 +1,174 @@
+import numpy as np
+import nibabel as nib
+import pytest
+import torch
+from scipy import ndimage
+
+import totalsegmentator.resampling as resampling
+from totalsegmentator.resampling import change_spacing
+
+
+def _blobs(shape, n_labels, seed=0):
+    rng = np.random.default_rng(seed)
+    field = ndimage.gaussian_filter(rng.random(shape), 2.0)
+    seg = np.zeros(shape, dtype=np.uint8)
+    for label in range(1, n_labels + 1):
+        seg[field > np.quantile(field, 1 - 0.6 * label / n_labels)] = label
+    return seg
+
+
+def _record_dispatch(monkeypatch):
+    """Which resampling implementation change_spacing actually reaches."""
+    called = []
+    for name in ("resample_img", "resample_img_torch", "resample_one_hot_crop"):
+        original = getattr(resampling, name)
+
+        def wrapper(*args, _name=name, _original=original, **kwargs):
+            called.append(_name)
+            return _original(*args, **kwargs)
+
+        monkeypatch.setattr(resampling, name, wrapper)
+    return called
+
+
+def test_torch_resample_does_not_intercept_one_hot_label_resampling(monkeypatch):
+    """The flag is scoped to intensity data: crop_resample keeps its own dispatch."""
+    seg = _blobs((20, 22, 18), 12)
+    img = nib.Nifti1Image(seg, np.diag([1.5, 1.5, 1.5, 1]))
+    called = _record_dispatch(monkeypatch)
+
+    change_spacing(img, 1.0, target_shape=(30, 33, 27), order=1, dtype=np.uint8,
+                   crop_resample=True, nr_cpus=1, torch_resample=True, device="cpu")
+
+    assert called == ["resample_one_hot_crop"], called
+
+
+def test_torch_resample_leaves_nearest_label_upsampling_on_scipy(monkeypatch):
+    """order=0 is out of scope for the flag and keeps its own dispatch."""
+    seg = _blobs((20, 22, 18), 12)
+    img = nib.Nifti1Image(seg, np.diag([1.5, 1.5, 1.5, 1]))
+    called = _record_dispatch(monkeypatch)
+
+    change_spacing(img, 1.0, target_shape=(30, 33, 27), order=0, dtype=np.uint8,
+                   nr_cpus=1, torch_resample=True, device="cpu")
+
+    assert called == ["resample_img"], called
+
+
+def test_torch_resample_still_handles_image_data(monkeypatch):
+    """The other side of the gate: intensity data at order>0 is what the backend is for."""
+    rng = np.random.default_rng(0)
+    img = nib.Nifti1Image(rng.random((20, 22, 18)).astype(np.float32), np.diag([1.5, 1.5, 1.5, 1]))
+    called = _record_dispatch(monkeypatch)
+
+    change_spacing(img, 1.0, target_shape=(30, 33, 27), order=3, dtype=np.float32,
+                   nr_cpus=1, torch_resample=True, device="cpu")
+
+    assert called == ["resample_img_torch"], called
+
+
+def test_one_hot_result_is_unchanged_by_the_torch_flag():
+    """Outside its scope the flag is inert: same voxels, same affine."""
+    seg = _blobs((20, 22, 18), 12)
+    img = nib.Nifti1Image(seg, np.diag([1.5, 1.5, 1.5, 1]))
+    kwargs = dict(target_shape=(30, 33, 27), order=1, dtype=np.uint8,
+                  crop_resample=True, nr_cpus=1)
+    stock = change_spacing(img, 1.0, **kwargs)
+    flagged = change_spacing(img, 1.0, torch_resample=True, device="cpu", **kwargs)
+    np.testing.assert_array_equal(np.asanyarray(stock.dataobj), np.asanyarray(flagged.dataobj))
+    np.testing.assert_allclose(stock.affine, flagged.affine)
+
+
+def _record_device(monkeypatch):
+    """The device string change_spacing hands to the torch backend, without running it."""
+    seen = {}
+
+    def fake(data, new_shape, device="mps", order=3, anti_alias=False):
+        seen["device"] = device
+        return np.zeros(new_shape, dtype=np.float32)
+
+    monkeypatch.setattr(resampling, "resample_img_torch", fake)
+    return seen
+
+
+def _intensity_image():
+    rng = np.random.default_rng(0)
+    return nib.Nifti1Image(rng.random((20, 22, 18)).astype(np.float32), np.diag([1.5, 1.5, 1.5, 1]))
+
+
+def test_torch_resample_keeps_the_cuda_device_index(monkeypatch):
+    """select_device() hands down a torch.device("cuda:N"), whose .type is only "cuda".
+    Dropping the N resamples on whichever CUDA device happens to be current while inference
+    runs on N - cross-device on a multi-GPU box, and on a shared cluster it reaches for a
+    GPU this process was not allocated."""
+    seen = _record_device(monkeypatch)
+
+    change_spacing(_intensity_image(), 1.0, target_shape=(30, 33, 27), order=3,
+                   dtype=np.float32, nr_cpus=1, torch_resample=True,
+                   device=torch.device("cuda:1"))
+
+    assert seen["device"] == "cuda:1"
+
+
+@pytest.mark.parametrize("device, expected", [("mps", "mps"), ("cpu", "cpu"), ("gpu", "cpu")])
+def test_torch_resample_normalizes_string_devices(monkeypatch, device, expected):
+    """Plain strings pass through; anything the backend cannot name falls back to the CPU."""
+    seen = _record_device(monkeypatch)
+
+    change_spacing(_intensity_image(), 1.0, target_shape=(30, 33, 27), order=3,
+                   dtype=np.float32, nr_cpus=1, torch_resample=True, device=device)
+
+    assert seen["device"] == expected
+
+
+@pytest.mark.parametrize("order", [1, 3])
+@pytest.mark.parametrize("new_shape", [(30, 33, 27), (11, 9, 14)])
+def test_resample_img_torch_reproduces_scipy_zoom(order, new_shape):
+    """The backend applies scipy's own per-axis operators, so it is not an approximation
+    of ndimage.zoom - it is ndimage.zoom, evaluated on torch."""
+    rng = np.random.default_rng(0)
+    vol = rng.random((20, 22, 18))
+
+    got = resampling.resample_img_torch(vol, new_shape, device="cpu", order=order)
+    zoom = tuple(n / o for n, o in zip(new_shape, vol.shape))
+    want = ndimage.zoom(vol, zoom, mode="nearest", order=order)
+
+    assert got.shape == want.shape
+    np.testing.assert_allclose(got, want, rtol=0, atol=1e-9)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="needs an MPS device")
+@pytest.mark.parametrize("order", [1, 3])
+def test_resample_img_torch_matches_scipy_on_mps(order):
+    """Same operators in float32 on the GPU: the residual is arithmetic, not sampling."""
+    rng = np.random.default_rng(0)
+    vol = rng.random((20, 22, 18))
+
+    got = resampling.resample_img_torch(vol, (30, 33, 27), device="mps", order=order)
+    want = ndimage.zoom(vol, (30 / 20, 33 / 22, 27 / 18), mode="nearest", order=order)
+
+    np.testing.assert_allclose(got, want, rtol=0, atol=1e-5)
+
+
+@pytest.mark.parametrize("order", [1, 3])
+def test_change_spacing_agrees_with_the_scipy_path(order):
+    """End to end through change_spacing: enabling the flag must not move the image."""
+    rng = np.random.default_rng(0)
+    img = nib.Nifti1Image(rng.random((20, 22, 18)) * 1000 - 500, np.diag([1.5, 1.5, 1.5, 1]))
+    kwargs = dict(target_shape=(30, 33, 27), order=order, dtype=np.float32, nr_cpus=1)
+
+    stock = change_spacing(img, 1.0, **kwargs)
+    torched = change_spacing(img, 1.0, torch_resample=True, device="cpu", **kwargs)
+
+    np.testing.assert_allclose(np.asanyarray(torched.dataobj), np.asanyarray(stock.dataobj),
+                               rtol=0, atol=1e-4)
+    np.testing.assert_allclose(torched.affine, stock.affine)
+
+
+def test_resample_img_torch_needs_no_forked_nnunet():
+    """The backend is numpy + scipy + torch. Requiring a fork of nnU-Net would make the
+    flag unusable against a released nnunetv2 and untestable in CI."""
+    import inspect
+
+    source = inspect.getsource(resampling.resample_img_torch)
+    assert "nnunetv2" not in source

--- a/totalsegmentator/bin/TotalSegmentator.py
+++ b/totalsegmentator/bin/TotalSegmentator.py
@@ -208,6 +208,12 @@ def main():
     parser.add_argument("-d",'--device', type=validate_device_type, default="gpu",
                         help="Device type: 'gpu', 'cpu', 'mps', or 'gpu:X' where X is an integer representing the GPU device ID.")
 
+    parser.add_argument('--torch-resample', action="store_true", default=False,
+                        help="Run the forward image resample through the torch backend on --device "
+                             "instead of CPU scipy. Reproduces scipy.ndimage.zoom (same corner-aligned "
+                             "sampling, spline order and rounding), and needs no cupy/cucim, so unlike "
+                             "the cucim path it also runs on Apple Silicon/MPS. Default off.")
+
     parser.add_argument("-q", "--quiet", action="store_true", help="Print no intermediate outputs",
                         default=False)
 
@@ -284,7 +290,7 @@ def main():
                      args.fast, args.nora_tag, args.preview, args.task, args.roi_subset,
                      args.statistics, args.radiomics, args.crop_path, args.body_seg,
                      args.force_split, args.output_type, args.quiet, args.verbose, args.test, args.skip_saving,
-                     device=args.device, license_number=args.license_number,
+                     device=args.device, torch_resample=args.torch_resample, license_number=args.license_number,
                      statistics_exclude_masks_at_border=not args.stats_include_incomplete,
                      no_derived_masks=args.no_derived_masks, v1_order=args.v1_order, fastest=args.fastest,
                      roi_subset_robust=args.roi_subset_robust, stats_aggregation=args.stats_aggregation, 

--- a/totalsegmentator/nnunet.py
+++ b/totalsegmentator/nnunet.py
@@ -469,7 +469,7 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
                          save_binary=False, nr_threads_resampling=1, nr_threads_saving=6, force_split=False,
                          crop_addon=[3,3,3], roi_subset=None, output_type="nifti",
                          statistics=False, quiet=False, verbose=False, test=0, skip_saving=False,
-                         device="cuda", exclude_masks_at_border=True, no_derived_masks=False,
+                         device="cuda", torch_resample=False, exclude_masks_at_border=True, no_derived_masks=False,
                          v1_order=False, stats_aggregation="mean", remove_small_blobs=False,
                          normalized_intensities=False, higher_order_resampling_LEGACY=False,
                          save_probabilities=None, cascade=None, remove_outside_mask=None, remove_outside_dilation=None,
@@ -660,7 +660,8 @@ def nnUNet_predict_image(file_in: Union[str, Path, Nifti1Image], file_out, task_
                 img_in_zooms = img_in.header.get_zooms()
                 img_in_rsp = change_spacing(
                     img_in, resample, order=resampling_order, dtype=np.int32,
-                    nr_cpus=nr_threads_resampling, use_gpu=use_gpu
+                    nr_cpus=nr_threads_resampling, use_gpu=use_gpu,
+                    torch_resample=torch_resample, device=device
                 )
                 if cascade:
                     cascade = change_spacing(

--- a/totalsegmentator/python_api.py
+++ b/totalsegmentator/python_api.py
@@ -208,7 +208,7 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
                      v1_order=False, fastest=False, roi_subset_robust=None, stats_aggregation="mean",
                      remove_small_blobs=False, statistics_normalized_intensities=False,
                      robust_crop=False, higher_order_resampling_LEGACY=False, higher_order_resampling=False,
-                     save_probabilities=None,
+                     save_probabilities=None, torch_resample=False,
                      debug=False, report=None, statistics_extra=False, save_lowres=False, resampling_order=1,
                      plans="nnUNetPlans", model_size="big"):
     """
@@ -492,7 +492,7 @@ def totalsegmentator(input: Union[str, Path, Nifti1Image], output: Union[str, Pa
                             stats_aggregation=stats_aggregation, remove_small_blobs=remove_small_blobs,
                             normalized_intensities=statistics_normalized_intensities,
                             higher_order_resampling_LEGACY=higher_order_resampling_LEGACY,
-                            save_probabilities=save_probabilities,
+                            save_probabilities=save_probabilities, torch_resample=torch_resample,
                             cascade=cascade, remove_outside_mask=remove_mask, remove_outside_dilation=remove_outside_dilation,
                             debug=debug, save_lowres=save_lowres,
                             resampling_order=resampling_order, plans=plans,

--- a/totalsegmentator/resampling.py
+++ b/totalsegmentator/resampling.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+import functools
 import importlib
 import multiprocessing
 
@@ -141,6 +142,69 @@ def resample_one_hot_crop(seg, new_shape, order=1, nr_cpus=1):
     return resampled
 
 
+@functools.lru_cache(maxsize=128)
+def _zoom_axis_operator(n_in, n_out, order, mode):
+    """The exact 1-D operator of ``scipy.ndimage.zoom`` along one axis, ``(n_out, n_in)`` float64.
+
+    ``zoom`` is linear and separable, so zooming an identity matrix along one axis *is* the
+    operator for that axis - spline prefilter, boundary mode and the corner-aligned
+    coordinate convention included, for any order. scipy builds these (they are tiny and
+    cached); torch applies them. Exact by construction: there is no sampling or boundary
+    handling reimplemented here to get subtly wrong.
+
+    ``grid_mode=False`` is what pins the convention: the voxel-corner point grid
+    ``change_spacing`` has always used. The same probe with ``grid_mode=True`` gives the
+    voxel-center (half-pixel) operator - ``skimage.resize``, and nnU-Net's own resampler.
+    The convention lives in the probe, not in anything below it.
+    """
+    if n_in == n_out:
+        return np.eye(n_in)
+    probe = ndimage.zoom(np.eye(n_in, dtype=np.float64), (1.0, n_out / n_in),
+                         order=order, mode=mode, grid_mode=False)
+    if probe.shape != (n_in, n_out):
+        raise RuntimeError(f"scipy zoom probe produced {probe.shape}, expected {(n_in, n_out)}")
+    return np.ascontiguousarray(probe.T)
+
+
+def resample_img_torch(data, new_shape, device="mps", order=3):
+    """GPU resample of a 3D intensity array [x,y,z] to ``new_shape`` on MPS / CUDA / CPU.
+
+    The torch analogue of ``resample_img`` / ``resample_img_cucim``. It does not
+    reimplement ``scipy.ndimage.zoom``; it applies scipy's own per-axis operators
+    (:func:`_zoom_axis_operator`) as matmuls on ``device``, so the result matches
+    ``ndimage.zoom(order=order, mode="nearest")`` to float precision on CPU and ~1e-6
+    relative on MPS/CUDA. Needs nothing beyond numpy, scipy and torch.
+
+    Intensity data only.
+    """
+    import torch
+
+    arr = np.asarray(data)
+    if arr.ndim != 3:
+        raise ValueError(f"expected a 3-D volume; got shape {arr.shape}")
+    new_shape = tuple(int(s) for s in new_shape)
+    if len(new_shape) != 3:
+        raise ValueError(f"new_shape must have 3 entries; got {new_shape}")
+
+    dev = torch.device(device)
+    # float64 is unsupported on MPS and unnecessary here: the operators are float32-exact
+    # to ~1e-7 relative, far below the intensity quantization these volumes carry.
+    work = torch.float64 if (dev.type == "cpu" and arr.dtype == np.float64) else torch.float32
+    t = torch.as_tensor(np.ascontiguousarray(arr), device=dev, dtype=work)
+    for axis in range(3):
+        n_in, n_out = int(t.shape[axis]), new_shape[axis]
+        if n_in == n_out:
+            continue
+        w = torch.as_tensor(_zoom_axis_operator(n_in, n_out, int(order), "nearest"),
+                            device=dev, dtype=work)
+        t = t.movedim(axis, -1)
+        shape = t.shape
+        t = (t.reshape(-1, shape[-1]) @ w.t()).reshape(*shape[:-1], w.shape[0]).movedim(-1, axis)
+    out = t.cpu().numpy()
+    del t
+    return out
+
+
 def resample_img_nnunet(data, mask=None, original_spacing=1.0, target_spacing=2.0,
                        order_data=3, order_seg=0):
     """
@@ -193,7 +257,7 @@ def resample_img_nnunet(data, mask=None, original_spacing=1.0, target_spacing=2.
 
 def change_spacing(img_in, new_spacing=1.25, target_shape=None, order=0, nr_cpus=1,
                    nnunet_resample=False, crop_resample=False, dtype=None, remove_negative=False,
-                   force_affine=None, use_gpu=False):
+                   force_affine=None, use_gpu=False, torch_resample=False, device="cpu"):
     """
     Resample nifti image to the new spacing (uses resample_img() internally).
 
@@ -278,7 +342,28 @@ def change_spacing(img_in, new_spacing=1.25, target_shape=None, order=0, nr_cpus
     if nnunet_resample and crop_resample:
         raise ValueError("Only one of nnunet_resample and crop_resample can be enabled.")
 
-    if nnunet_resample:
+    # Opt-in torch resampling backend (torch_resample=True; runs on `device`).
+    # torch-based, so it runs on Apple Silicon (MPS) where the cucim path cannot, and it
+    # applies scipy's own zoom operators, so results match the CPU path.
+    #
+    # Scope: forward image intensity data (order > 0).
+    _one_hot = nnunet_resample or crop_resample      # both mean "resample labels, not intensities"
+    _use_torch = torch_resample and data.ndim == 3 and order != 0 and not _one_hot
+    if _use_torch:
+        # Keep the device INDEX. select_device() hands down a torch.device("cuda:N"), whose
+        # .type is just "cuda" - resampling on that would land on whichever CUDA device is
+        # current while inference runs on N: cross-device on a multi-GPU box, and on a
+        # shared cluster it reaches for a GPU this process was not allocated.
+        _dev = str(device)
+        _kind = device.type if hasattr(device, "type") else _dev.split(":")[0]
+        if _kind not in ("mps", "cuda", "cpu"):
+            _dev = "cpu"
+        if target_shape is not None:
+            new_shape = tuple(int(s) for s in target_shape)
+        else:
+            new_shape = tuple(int(round(o * z)) for o, z in zip(old_shape, zoom))
+        new_data = resample_img_torch(data, new_shape, device=_dev, order=order)
+    elif nnunet_resample:
         # new_data, _ = resample_img_nnunet(data, None, img_spacing, new_spacing, order_data=order, order_seg=order)
         _, new_data = resample_img_nnunet(None, data, img_spacing, new_spacing, order_data=order, order_seg=order)
     elif crop_resample:


### PR DESCRIPTION
`change_spacing` gains `torch_resample=False` and `device`. When enabled, the forward image
resample runs on `device` through torch instead of on one CPU through scipy. Needs only
numpy, scipy and torch - no cupy/cucim, so unlike the cucim path it runs on Apple Silicon too.

### It does not reimplement `ndimage.zoom`

`zoom` is linear and separable, so zooming an identity matrix along one axis *is* the operator
for that axis - spline prefilter, boundary mode and the corner-aligned convention included, for
any order. scipy builds one such matrix per axis (they are tiny, and cached); torch applies them
as matmuls. There is no sampling or boundary handling reimplemented here to get subtly wrong.

### Scope

Intensity data at `order > 0`. Every other `change_spacing` call - the cascade label resample,
both label-inverse branches - keeps its existing dispatch, so output is unchanged unless the flag
is passed. The device keeps its index, so on a multi-GPU box the resample runs on the same CUDA
device as inference.

### Why against `totalseg_v3`

`total_highres` resamples to 0.75 x 0.75 x 1.0 mm. On a 512x512x807 CT at 0.82x0.82x1.0 that is
253 M output voxels against 42 M for `total` at 1.5 mm - six times the work through
`change_spacing`, on the task whose docs already warn about runtime.

### Measured

512x512x600 at 0.82x0.82x1.0 mm -> 1.5 mm isotropic, order 3, against scipy on the same host:

| host | scipy, 1 cpu | torch | |
| --- | --- | --- | --- |
| Apple M2, torch 2.13 | 11.32 s | mps 0.52 s | 21.9x |
| AWS A10G, torch 2.14 | 14.14 s | cuda 0.14 s | 102.9x |
| x86, 16 cores | 10.57 s | cpu 0.70 s | 15.2x |
| x86, 8 cores | 13.63 s | cpu 1.04 s | 13.1x |

Agreement with `ndimage.zoom` is 5e-7 or better on the GPUs and exact to float64 on the CPU.
The CPU speedup varies with the host CPU and core count, unlike scipy.

### Tests

`tests/test_resampling.py` is new: parity against `ndimage.zoom` at orders 1 and 3, the dispatch
for every `change_spacing` leg, device handling, and that the flag is inert outside its scope. It
needs no GPU and no weights, so it runs in CI as is.

Validation also ran on a 2x A10G box: parity on CUDA, and the device index confirmed by checking
that a resample requested on `cuda:1` actually lands there.
